### PR TITLE
In process communicator

### DIFF
--- a/crypten/communicator/communicator.py
+++ b/crypten/communicator/communicator.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+
 import torch
 
 
@@ -25,9 +27,24 @@ class Communicator:
         assert isinstance(verbosity, bool), "Verbosity must be a boolean value"
         cls.__verbosity = verbosity
 
-    def initialize(self, **kwargs):
+    @classmethod
+    def is_initialized(cls):
+        """Returns whether the communicator has been initialized"""
+        raise NotImplementedError("is_initialized is not implemented")
+
+    @classmethod
+    def get(cls):
+        """Returns an instance of the communicator"""
+        raise NotImplementedError("get is not implemented")
+
+    @classmethod
+    def initialize(cls, **kwargs):
         """Initializes the communicator. Call this function before using it."""
-        pass
+        raise NotImplementedError("initialize is not implemented")
+
+    @classmethod
+    def shutdown(cls):
+        raise NotImplementedError("shutdown is not implemented")
 
     def send(self, tensor, dst):
         """Sends the specified tensor to the destination dst."""
@@ -89,8 +106,21 @@ class Communicator:
         """Updates log of communication statistics."""
         raise NotImplementedError("_log_communication is not implemented")
 
-    def shutdown(self):
-        raise NotImplementedError("shutdown is not implemented")
+    def reset_communication_stats(self):
+        """Resets communication statistics."""
+        self.comm_rounds = 0
+        self.comm_bytes = 0
+
+    def print_communication_stats(self):
+        """Prints communication statistics."""
+        logging.info("====Communication Stats====")
+        logging.info("Rounds: %d" % self.comm_rounds)
+        logging.info("Bytes : %d" % self.comm_bytes)
+
+    def _log_communication(self, nelement):
+        """Updates log of communication statistics."""
+        self.comm_rounds += 1
+        self.comm_bytes += nelement * self.BYTES_PER_ELEMENT
 
 
 def _logging(func):

--- a/crypten/communicator/in_process_communicator.py
+++ b/crypten/communicator/in_process_communicator.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+import logging
+import threading
+from operator import itemgetter
+from queue import Queue
+
+import torch
+from torch.distributed import ReduceOp
+
+from .communicator import Communicator
+
+
+class InProcessCommunicator(Communicator):
+
+    BYTES_PER_ELEMENT = 8
+    tls = threading.local()
+    mailbox = None
+    barrier = None
+    lock = threading.Lock()
+
+    @classmethod
+    def initialize(cls, rank, world_size):
+        cls.tls.instance = cls(rank, world_size)
+
+    def __init__(self, rank, world_size):
+        self.world_size = world_size
+        self.rank = rank
+        self.reset_communication_stats()
+
+        with InProcessCommunicator.lock:
+            if InProcessCommunicator.mailbox is None:
+                InProcessCommunicator.mailbox = [
+                    Queue() for _ in range(self.world_size)
+                ]
+
+                # This prevents one thread from running ahead of the others and doing
+                # multiple puts that would show up in the get calls below
+                InProcessCommunicator.barrier = threading.Barrier(self.world_size)
+
+        # logging:
+        level = logging.getLogger().level
+        logging.getLogger().setLevel(logging.INFO)
+        logging.info("==================")
+        logging.info("InProcessCommunicator with rank %d" % self.rank)
+        logging.info("==================")
+
+        logging.info("World size = %d" % self.get_world_size())
+        logging.getLogger().setLevel(level)
+
+    @classmethod
+    def get(cls):
+        if not hasattr(cls.tls, "instance"):
+            return None
+
+        return cls.tls.instance
+
+    @classmethod
+    def is_initialized(cls):
+        return hasattr(cls.tls, "instance")
+
+    def send(self, tensor, dst):
+        """Sends the specified tensor to the destination dst."""
+        self.mailbox[dst].put((self.rank, tensor.clone()))
+
+    def recv(self, tensor, src=None):
+        """Receives a tensor from an (optional) source src."""
+        rank, result = self.mailbox[self.rank].get()
+        if src is not None and rank != src:
+            raise NotImplementedError("Can't receive messages out of order yet")
+        return result
+
+    def isend(self, tensor, dst):
+        """Sends the specified tensor to the destination dst."""
+        self.send(tensor, dst)
+
+        class Result:
+            def is_completed(self):
+                return True
+
+            def wait(self):
+                pass
+
+        return Result()
+
+    def irecv(self, tensor, src=None):
+        """Receives a tensor from an (optional) source src."""
+
+        class Result:
+            def __init__(self, mailbox, rank):
+                self.completed = False
+                self.mailbox = mailbox
+                self.rank = rank
+
+            def is_completed(self):
+                return self.completed
+
+            def wait(self):
+                rank, result = self.mailbox[self.rank].get()
+                if src is not None and rank != src:
+                    raise NotImplementedError("Can't receive messages out of order yet")
+                tensor.copy_(result)
+
+        return Result(self.mailbox, self.rank)
+
+    def scatter(self, scatter_list, src, size=None, async_op=False):
+        """Scatters a list of tensors to all parties."""
+        if async_op:
+            raise NotImplementedError()
+
+        if src == self.rank:
+            for i in range(self.world_size):
+                self.mailbox[i].put(scatter_list[i].clone())
+
+        self.barrier.wait()
+
+        return self.mailbox[self.rank].get()
+
+    def reduce(self, tensor, dst, op=ReduceOp.SUM, async_op=False):
+        """Reduces the tensor data across all parties."""
+        tensors = self.gather(tensor, dst)
+        if self.rank == dst:
+            reduce_fn = self._reduce_op_to_function(op)
+            return reduce_fn(torch.stack(tensors), dim=0)
+
+    @classmethod
+    def shutdown(cls):
+        # Destroy all thread-local instances
+        cls.tls = threading.local()
+        cls.mailbox = None
+        cls.barrier = None
+
+    def _reduce_op_to_function(self, op):
+        if op == ReduceOp.SUM:
+            return torch.sum
+
+        raise NotImplementedError()
+
+    def all_reduce(self, tensor, op=ReduceOp.SUM, async_op=False):
+        """Reduces the tensor data across all parties; all get the final result."""
+        if async_op:
+            raise NotImplementedError()
+
+        ag = self.all_gather(tensor)
+        reduce_fn = self._reduce_op_to_function(op)
+        return reduce_fn(torch.stack(ag), dim=0)
+
+    def gather(self, tensor, dst, async_op=False):
+        """Gathers a list of tensors in a single party."""
+        if async_op:
+            raise NotImplementedError()
+
+        self.mailbox[dst].put((self.rank, tensor.clone()))
+
+        self.barrier.wait()
+
+        if self.rank == dst:
+            result = [self.mailbox[dst].get() for _ in range(self.world_size)]
+            return [tensor for rank, tensor in sorted(result, key=itemgetter(0))]
+
+    def all_gather(self, tensor, async_op=False):
+        """Gathers tensors from all parties in a list."""
+        if async_op:
+            raise NotImplementedError()
+
+        for i in range(self.world_size):
+            self.mailbox[i].put((self.rank, tensor.clone()))
+
+        self.barrier.wait()
+
+        result = sorted(
+            (self.mailbox[self.rank].get() for _ in range(self.world_size)),
+            key=itemgetter(0),
+        )
+
+        return [tensor for (rank, tensor) in result]
+
+    def broadcast(self, tensor, src, async_op=False):
+        """Broadcasts the tensor to all parties."""
+        if async_op:
+            raise NotImplementedError()
+
+        if self.rank == src:
+            for i in range(self.get_world_size()):
+                self.mailbox[i].put(tensor.clone())
+
+        # No need for a barrier here.
+
+        return self.mailbox[self.rank].get()
+
+    def get_world_size(self):
+        """Returns the size of the world."""
+        return self.world_size
+
+    def get_rank(self):
+        """Returns the rank of the current process."""
+        return self.rank

--- a/crypten/mpc/context.py
+++ b/crypten/mpc/context.py
@@ -13,6 +13,7 @@ import tempfile
 from operator import itemgetter
 
 import crypten
+from crypten.communicator import DistributedCommunicator
 
 
 def _launch(func, rank, world_size, rendezvous_file, queue, func_args, func_kwargs):
@@ -56,8 +57,9 @@ def run_multiprocess(world_size):
             # process.  An alternative fix for this issue would be to use spawn
             # instead of fork, but we run into issues serializing the function
             # in that case.
-            was_initialized = crypten.communicator.__is_initialized
-            crypten.uninit()
+            was_initialized = DistributedCommunicator.is_initialized()
+            if was_initialized:
+                crypten.uninit()
 
             for process in processes:
                 process.start()

--- a/test/multiprocess_test_case.py
+++ b/test/multiprocess_test_case.py
@@ -179,6 +179,8 @@ class MultiProcessTestCase(unittest.TestCase):
         for key, val in communicator_args.items():
             os.environ[key] = str(val)
 
+        crypten.init()
+
         self.setUp()
 
         # We're retrieving a corresponding test and executing it.

--- a/test/multithread_test_case.py
+++ b/test/multithread_test_case.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import queue
+import sys
+import threading
+import unittest
+from functools import wraps
+from threading import Thread
+
+import crypten
+
+from .benchmark_helper import BenchmarkHelper
+
+
+class MultiThreadTestCase(unittest.TestCase):
+    MAIN_PROCESS_RANK = -1
+
+    @property
+    def rank(self):
+        from crypten.communicator import InProcessCommunicator
+
+        if threading.current_thread() == threading.main_thread():
+            return self.MAIN_PROCESS_RANK
+
+        return InProcessCommunicator.get().rank
+
+    @property
+    def world_size(self):
+        return 2
+
+    def __init__(self, methodName):
+        super().__init__(methodName)
+        # TODO(vini): support benchmarking in threaded mode
+        self.benchmark_iters = 1
+        self.benchmark_enabled = False
+        self.default_tolerance = 0.5
+        q = queue.Queue()
+        self.benchmark_helper = BenchmarkHelper(False, self.world_size, q)
+
+    def benchmark(self, niters=None, data=None, **kwargs):
+        return self.benchmark_helper.benchmark(self, niters, data, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
+        for attr in dir(cls):
+            if attr.startswith("test"):
+                fn = getattr(cls, attr)
+                setattr(cls, attr, cls.join_or_run(fn))
+
+    @staticmethod
+    def join_or_run(fn):
+        @wraps(fn)
+        def wrapper(self):
+            if threading.current_thread() == threading.main_thread():
+                self._join_threads()
+            else:
+                fn(self)
+
+        return wrapper
+
+    def _join_threads(self):
+        for t in self.threads:
+            t.join()
+
+        try:
+            exception_info = self.exception_queue.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            sys.excepthook(*exception_info)
+            raise RuntimeError(
+                "Exception found in one of the parties. Look at past logs."
+            )
+
+    def _current_test_name(self):
+        # self.id() == e.g. '__main__.TestDistributed.TestAdditive.test_get_rank'
+        return self.id().split(".")[-1]
+
+    def setUp(self):
+        super().setUp()
+
+        if threading.current_thread() != threading.main_thread():
+            return
+        test_name = self._current_test_name()
+        test_fn = getattr(self, test_name)
+        self.exception_queue = queue.Queue()
+        self.threads = [
+            Thread(target=self._run, args=(test_fn, rank, self.world_size))
+            for rank in range(self.world_size)
+        ]
+        for t in self.threads:
+            t.start()
+
+    def _run(self, test_fn, rank, world_size):
+        crypten.init_thread(rank, world_size)
+
+        self.setUp()
+
+        try:
+            test_fn()
+        except Exception:
+            self.exception_queue.put(sys.exc_info())

--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -11,6 +11,7 @@ import logging
 import math
 import unittest
 from test.multiprocess_test_case import MultiProcessTestCase, get_random_test_tensor
+from test.multithread_test_case import MultiThreadTestCase
 
 import crypten
 import torch
@@ -19,18 +20,12 @@ from crypten.common.tensor_types import is_float_tensor
 from crypten.mpc import MPCTensor, ptype
 
 
-class TestMPC(MultiProcessTestCase):
+class TestMPC:
     """
         This class tests all functions of MPCTensor.
     """
 
     benchmarks_enabled = False
-
-    def setUp(self):
-        super().setUp()
-        # We don't want the main process (rank -1) to initialize the communicator
-        if self.rank >= 0:
-            crypten.init()
 
     def _check(self, encrypted_tensor, reference, msg, tolerance=None):
         if tolerance is None:
@@ -1527,8 +1522,16 @@ class TestMPC(MultiProcessTestCase):
         pass
 
 
+class TestMPCThreads(TestMPC, MultiThreadTestCase):
+    pass
+
+
+class TestMPCProcess(TestMPC, MultiProcessTestCase):
+    pass
+
+
 # This code only runs when executing the file outside the test harness (e.g.
 # via the buck target test_mpc_benchmark)
 if __name__ == "__main__":
-    TestMPC.benchmarks_enabled = True
+    TestMPCProcess.benchmarks_enabled = True
     unittest.main()


### PR DESCRIPTION
Summary:
Implements a communicator that does message passing between threads instead of
communicating between multiple processes. This is useful for multiple reasons:
 1) Threads are easier to debug;
 2) This works on Windows (torch.distributed doesn't);
 3) This runs much faster (no spawn/forking involved);

This adds a new base class for our tests (MultiThreadedTestCase) which is
analogous to MultiProcessTestCase, and makes all tests run on both
environments.

To get this working I needed a few seemingly unrelated changes:
 - Implement isend/irecv in DistributedCommunicator; We were previously
   calling torch.distributed directly;
 - Move the PRZS code to crypten.init instead of doing it in the communicator;
   That allows sharing the implementation between multiple communicators;

Differential Revision: D17113829

