### PR TITLE
_launch wasn't setting env variables appropriately

### DIFF
--- a/crypten/mpc/context.py
+++ b/crypten/mpc/context.py
@@ -21,7 +21,7 @@ def _launch(func, rank, world_size, rendezvous_file, queue, func_args, func_kwar
         "WORLD_SIZE": world_size,
         "RANK": rank,
         "RENDEZVOUS": "file://%s" % rendezvous_file,
-        "BACKEND": "gloo",
+        "DISTRIBUTED_BACKEND": "gloo",
     }
     for key, val in communicator_args.items():
         os.environ[key] = str(val)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The DistributedCommunicator is waiting for the backend to be set using the DISTRIBUTED_BACKEND env variable [here](https://github.com/facebookresearch/CrypTen/blob/master/crypten/communicator/distributed_communicator.py#L34) but the code was setting the BACKEND env variable instead.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
