### PR TITLE
Package CrypTen on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img width="70%" src="docs/\_static/img/CrypTen_Identity_Horizontal_Lockup_01_FullColor.png" alt="CrypTen logo" /></p>
+<p align="center"><img width="70%" src="https://raw.githubusercontent.com/facebookresearch/CrypTen/master/docs/_static/img/CrypTen_Identity_Horizontal_Lockup_01_FullColor.png" alt="CrypTen logo" /></p>
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookresearch/CrypTen/blob/master/LICENSE) [![CircleCI](https://circleci.com/gh/facebookresearch/CrypTen.svg?style=shield)](https://circleci.com/gh/facebookresearch/CrypTen/tree/master) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/facebookresearch/CrypTen/blob/master/CONTRIBUTING.md)
 
@@ -41,19 +41,13 @@ It is currently not production ready and its main use is as a research framework
 
 ## Installing CrypTen
 
-CrypTen currently runs on Linux and Mac. It also needs a PyTorch nightly build.
+CrypTen currently runs on Linux and Mac with Python >= 3.7.
 Windows is not supported. We also do not currently support computation on GPUs.
 
-Install Anaconda 2019.07 or later and then do the following:
 
 _For Linux or Mac_
 ```bash
-conda create -n crypten-env python=3.7
-conda activate crypten-env
-conda install pytorch torchvision -c pytorch
-git clone https://github.com/facebookresearch/CrypTen.git
-cd CrypTen
-pip install -e .
+pip install crypten
 ```
 
 If you want to run the examples in the `examples` directory, you should also do the following

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+torch==1.4.0
+torchvision==0.5.0
 onnx
 tensorboard
 future

--- a/setup.py
+++ b/setup.py
@@ -13,20 +13,18 @@ import setuptools
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "crypten"))
 
-# Read description, license and requirements.
+# Read description and requirements.
 with open("README.md", encoding="utf8") as f:
     readme = f.read()
-with open("LICENSE") as f:
-    license = f.read()
 with open("requirements.txt") as f:
     reqs = f.read()
 
 # Set key package information.
 DISTNAME = "crypten"
-DESCRIPTION = "CrypTen: Private and secure machine learning in PyTorch."
+DESCRIPTION = "CrypTen: secure machine learning in PyTorch."
 LONG_DESCRIPTION = readme
 AUTHOR = "Facebook AI Research"
-LICENSE = license
+LICENSE = "MIT licensed, as found in the LICENSE file"
 REQUIREMENTS = (reqs.strip().split("\n"),)
 
 # Run installer.
@@ -39,6 +37,8 @@ if __name__ == "__main__":
         version="0.1",
         description=DESCRIPTION,
         long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/markdown",
+        url="https://github.com/facebookresearch/CrypTen",
         author=AUTHOR,
         license=LICENSE,
         setup_requires=["pytest-runner"],


### PR DESCRIPTION
Summary:
CrypTen is now a proper [PyPI package](https://pypi.org/project/crypten/0.1/), making installation one step: `pip install crypten`.

* update readme with new installation instructions
* add logo raw link so it renders on PyPI
* update license and project url in `setup.py`
* specific version of `torch` and `torchvision` now specified in `requirements.txt` and automatically installed via pip

We can now also track installation statistics via PyPI.

Differential Revision: D19746436

