### PR TITLE
Implement BCEWithLogitsLoss

### DIFF
--- a/crypten/autograd_cryptensor.py
+++ b/crypten/autograd_cryptensor.py
@@ -69,7 +69,10 @@ class AutogradCrypTensor(object):
     def __init__(self, tensor, requires_grad=True):
         if torch.is_tensor(tensor):
             raise ValueError("Cannot create AutogradCrypTensor from PyTorch tensor.")
-        self._tensor = tensor  # value of tensor
+        if isinstance(tensor, AutogradCrypTensor):
+            self._tensor = tensor._tensor.shallow_copy()
+        else:
+            self._tensor = tensor  # value of tensor
         self.requires_grad = requires_grad  # whether tensors needs gradient
         self._reset_gradients()
 

--- a/crypten/nn/__init__.py
+++ b/crypten/nn/__init__.py
@@ -12,7 +12,7 @@ import torch
 import torch.onnx.utils
 from onnx import numpy_helper
 
-from .loss import BCELoss, CrossEntropyLoss, L1Loss, MSELoss
+from .loss import BCELoss, BCEWithLogitsLoss, CrossEntropyLoss, L1Loss, MSELoss
 from .module import (
     Add,
     AvgPool2d,
@@ -63,6 +63,7 @@ __all__ = [
     "MSELoss",
     "L1Loss",
     "BCELoss",
+    "BCEWithLogitsLoss",
     "Add",
     "AvgPool2d",
     "_BatchNorm",


### PR DESCRIPTION
Summary:
See section 2.1 in https://arxiv.org/pdf/2002.04344.pdf

This diff implements:
- `binary_cross_entropy_with_logits` gradient function
- `BCEWithLogitsLoss` in loss.py that acts as a Sigmoid + BCELoss layer
- `skip_forward` kwarg in `_Loss` functions that allows the user to specify whether to compute the full loss or only compute its gradient.
- Tests for all of the above and improved tests for loss functions in `test_nn` that tests `backward` for loss functions
- Fix for L1Loss backward (AutogradCrypTensor could wrap other AutogradCrypTensors which caused a bug)

Reviewed By: marksibrahim

Differential Revision: D19878664

