### PR TITLE
Add registration mechanism for CrypTensor types

### DIFF
--- a/crypten/gradients.py
+++ b/crypten/gradients.py
@@ -422,7 +422,8 @@ class AutogradReLU(AutogradFunction):
 class AutogradDropout(AutogradFunction):
     @staticmethod
     def forward(ctx, input, p=0.5, inplace=False):
-        rand_tensor = crypten.mpc.rand(input.size())
+        cryptensor_type = crypten.get_cryptensor_type(input)
+        rand_tensor = crypten.rand(input.size(), cryptensor_type=cryptensor_type)
         boolean_mask = rand_tensor > p
         if inplace:
             result = input.mul_(boolean_mask).div_(1 - p)
@@ -442,7 +443,10 @@ class AutogradFeatureDropout(AutogradFunction):
     @staticmethod
     def forward(ctx, input, p=0.5, inplace=False):
         feature_dropout_size = input.size()[0:2]
-        rand_tensor = crypten.mpc.rand(feature_dropout_size)
+        cryptensor_type = crypten.get_cryptensor_type(input)
+        rand_tensor = crypten.rand(
+            feature_dropout_size, cryptensor_type=cryptensor_type
+        )
         boolean_mask = rand_tensor > p
         for i in range(2, input.dim()):
             boolean_mask = boolean_mask.unsqueeze(i)

--- a/crypten/mpc/__init__.py
+++ b/crypten/mpc/__init__.py
@@ -7,7 +7,6 @@
 
 import os
 
-import torch
 from crypten.mpc import primitives  # noqa: F401
 from crypten.mpc import provider  # noqa: F40
 
@@ -17,70 +16,6 @@ from .ptype import ptype
 
 
 __all__ = ["MPCTensor", "primitives", "provider", "ptype", "run_multiprocess"]
-
-
-def __cat_stack_helper(op, tensors, *args, **kwargs):
-    assert op in ["cat", "stack"], "Unsupported op for helper function"
-    assert isinstance(tensors, list), "%s input must be a list" % op
-    assert len(tensors) > 0, "expected a non-empty list of MPCTensors"
-
-    _ptype = kwargs.pop("ptype", None)
-    # Populate ptype field
-    if _ptype is None:
-        for tensor in tensors:
-            if isinstance(tensor, MPCTensor):
-                _ptype = tensor.ptype
-                break
-    if _ptype is None:
-        _ptype = ptype.arithmetic
-
-    # Make all inputs MPCTensors of given ptype
-    for i, tensor in enumerate(tensors):
-        if torch.is_tensor(tensor):
-            tensors[i] = MPCTensor(tensor, ptype=_ptype)
-        assert isinstance(tensors[i], MPCTensor), "Can't %s %s with MPCTensor" % (
-            op,
-            type(tensor),
-        )
-        if tensors[i].ptype != _ptype:
-            tensors[i] = tensors[i].to(_ptype)
-
-    # Operate on all input tensors
-    result = tensors[0].clone()
-    result.share = getattr(torch, op)(
-        [tensor.share for tensor in tensors], *args, **kwargs
-    )
-    return result
-
-
-def cat(tensors, *args, **kwargs):
-    """Perform matrix concatenation"""
-    return __cat_stack_helper("cat", tensors, *args, **kwargs)
-
-
-def stack(tensors, *args, **kwargs):
-    """Perform tensor stacking"""
-    return __cat_stack_helper("stack", tensors, *args, **kwargs)
-
-
-def rand(*sizes):
-    """
-    Returns a tensor with elements uniformly sampled in [0, 1) using the
-    trusted third party.
-    """
-    rand = MPCTensor(None)
-    rand._tensor = __default_provider.rand(*sizes)
-    rand.ptype = ptype.arithmetic
-    return rand
-
-
-def bernoulli(tensor):
-    """
-    Returns a tensor with elements in {0, 1}. The i-th element of the
-    output will be 1 with probability according to the i-th value of the
-    input tensor.
-    """
-    return rand(tensor.size()) < tensor
 
 
 # Set provider

--- a/examples/bandits/private_contextual_bandits.py
+++ b/examples/bandits/private_contextual_bandits.py
@@ -43,7 +43,7 @@ def online_learner(
     total_reward = 0.0
 
     # initialize constructor for tensors:
-    crypten.set_default_backend(getattr(crypten, backend))
+    crypten.set_default_backend(backend)
 
     # loop over dataset:
     idx = 0


### PR DESCRIPTION
Summary:
This diff adds a registration mechanism for custom `CrypTensor`s. Using this mechanism, you can develop a custom `CrypTensor` type outside of the core CrypTen codebase and register it in CrypTen.

To get this working, I needed to make a few breaking changes:
- Renamed `{get, set}_default_backend()` functions.
- Removed static functions `crypten.mpc.rand()` and `crypten.mpc.bernoulli()`. Instead, one should now use `crypten.rand()` and `crypten.bernoulli()` with an optional `cryptensor_type` for the output or call `MPCTensor.rand()` and `MPCTensor.bernoulli()` directly.
- Similar changes for `crypten.mpc.stack()` and `crypten.mpc.cat()`. For those functions, I also removed the functionality that allowed one to provide PyTorch tensors or a mix of CrypTen and PyTorch tensors as input — this simplifies the code and removes undefined behavior when a list with two different `CrypTensor` subtypes is provided as input.

Reviewed By: shubho

Differential Revision: D19850066

