### PR TITLE
Fix `test_prod` and `test_max_min` circle ci flakiness

### DIFF
--- a/test/test_arithmetic.py
+++ b/test/test_arithmetic.py
@@ -181,12 +181,11 @@ class TestArithmetic(MultiProcessTestCase):
 
     def test_prod(self):
         """Tests prod reduction on encrypted tensor."""
-        # Increaing size to reduce relative error due to quantization
-        tensor = get_random_test_tensor(size=(5, 5, 5), is_float=False)
+        tensor = get_random_test_tensor(size=(3, 3), max_value=3, is_float=False)
         encrypted = ArithmeticSharedTensor(tensor)
         self._check(encrypted.prod(), tensor.prod().float(), "prod failed")
 
-        for dim in [0, 1, 2]:
+        for dim in [0, 1]:
             reference = tensor.prod(dim).float()
             encrypted_out = encrypted.prod(dim)
             self._check(encrypted_out, reference, "prod failed")

--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -193,7 +193,7 @@ class TestMPC(object):
 
     def test_prod(self):
         """Tests prod reduction on encrypted tensor."""
-        tensor = get_random_test_tensor(size=(5, 5), is_float=False)
+        tensor = get_random_test_tensor(size=(3, 3), max_value=3, is_float=False)
         encrypted = MPCTensor(tensor)
         self._check(encrypted.prod(), tensor.prod().float(), "prod failed")
 
@@ -574,7 +574,7 @@ class TestMPC(object):
                         mpc_result = tensor.gather(dim, out_decr)
                         torch_result = tensor.gather(dim, argmax_ref)
                         self.assertTrue(
-                            (mpc_result == torch_result).all().item(),
+                            torch.allclose(mpc_result, torch_result, rtol=1e-1),
                             "%s reduction failed" % comp,
                         )
 
@@ -589,10 +589,11 @@ class TestMPC(object):
                         out_decr = out_encr.get_plain_text()
                         self.assertTrue((out_decr.sum(dim=dim) == 1).all())
                         self.assertTrue(
-                            (
-                                out_decr.mul(tensor).sum(dim=dim, keepdim=keepdim)
-                                == val_ref
-                            ).all()
+                            torch.allclose(
+                                out_decr.mul(tensor).sum(dim=dim, keepdim=keepdim),
+                                val_ref,
+                                rtol=1e-1,
+                            )
                         )
 
     def test_argmax_argmin(self):


### PR DESCRIPTION
Summary:
Previously `test_prod` failed 42% of runs and `test_max_min` failed .3% of runs using open source Python.

This diff

* reduces size of prod test to (3, 3) and max_value to 3 limiting the size of the output to 19683 (instead of previous 2.8e19).
* adjusts argmax value checking to use `torch.allclose()` with `rtol=1e-1` in case of close values.

Both tests now have 0 failures out of 1k runs.

Differential Revision: D19981051

