### PR TITLE
Allow interchangeable encoders

### DIFF
--- a/crypten/__init__.py
+++ b/crypten/__init__.py
@@ -8,6 +8,7 @@
 __version__ = "0.1.0"
 
 import crypten.communicator as comm
+import crypten.encoder  # noqa: F401
 import crypten.mpc  # noqa: F401
 import crypten.nn  # noqa: F401
 import torch

--- a/crypten/encoder/__init__.py
+++ b/crypten/encoder/__init__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .fixed_point_encoder import FixedPointEncoder
+
+
+__all__ = ["FixedPointEncoder"]
+
+__SUPPORTED_ENCODERS = [FixedPointEncoder]
+__default_encoder = __SUPPORTED_ENCODERS[0]
+
+
+def get_default_encoder():
+    return __default_encoder
+
+
+def set_default_encoder(encoder):
+    assert (
+        encoder in __SUPPORTED_ENCODERS
+    ), f"Provided encoder is not supported {encoder}"
+    global __default_encoder
+    __default_encoder = encoder
+
+
+def set_default_precision(precision_bits):
+    assert (
+        isinstance(precision_bits, int) and precision_bits >= 0 and precision_bits < 64
+    ), "precision must be a positive integer less than 64"
+    FixedPointEncoder.set_default_precision(precision_bits)

--- a/crypten/mpc/primitives/arithmetic.py
+++ b/crypten/mpc/primitives/arithmetic.py
@@ -14,7 +14,7 @@ import torch
 from crypten.common.rng import generate_random_ring_element
 from crypten.common.tensor_types import is_float_tensor, is_int_tensor
 from crypten.cryptensor import CrypTensor
-from crypten.encoder import FixedPointEncoder
+from crypten.encoder import get_default_encoder
 
 from . import beaver
 
@@ -40,7 +40,7 @@ class ArithmeticSharedTensor(CrypTensor):
             isinstance(src, int) and src >= 0 and src < comm.get().get_world_size()
         ), "invalid tensor source"
 
-        self.encoder = FixedPointEncoder(precision_bits=precision)
+        self.encoder = get_default_encoder()(precision_bits=precision)
         if tensor is not None:
             if is_int_tensor(tensor) and precision != 0:
                 tensor = tensor.float()
@@ -72,7 +72,7 @@ class ArithmeticSharedTensor(CrypTensor):
         """Generate an ArithmeticSharedTensor from a share from each party"""
         result = ArithmeticSharedTensor(src=SENTINEL)
         result.share = share
-        result.encoder = FixedPointEncoder(precision_bits=precision)
+        result.encoder = get_default_encoder()(precision_bits=precision)
         return result
 
     @staticmethod

--- a/crypten/mpc/primitives/binary.py
+++ b/crypten/mpc/primitives/binary.py
@@ -13,7 +13,7 @@ import crypten.communicator as comm
 import torch
 from crypten.common.rng import generate_kbit_random_tensor
 from crypten.cryptensor import CrypTensor
-from crypten.encoder import FixedPointEncoder
+from crypten.encoder import get_default_encoder
 
 from . import beaver, circuit
 
@@ -39,7 +39,7 @@ class BinarySharedTensor(CrypTensor):
         ), "invalid tensor source"
 
         #  Assume 0 bits of precision unless encoder is set outside of init
-        self.encoder = FixedPointEncoder(precision_bits=0)
+        self.encoder = get_default_encoder()(precision_bits=0)
         if tensor is not None:
             tensor = self.encoder.encode(tensor)
             size = tensor.size()
@@ -59,7 +59,7 @@ class BinarySharedTensor(CrypTensor):
         """Generate a BinarySharedTensor from a share from each party"""
         result = BinarySharedTensor(src=SENTINEL)
         result.share = share
-        result.encoder = FixedPointEncoder(precision_bits=0)
+        result.encoder = get_default_encoder()(precision_bits=0)
         return result
 
     @staticmethod

--- a/crypten/mpc/primitives/converters.py
+++ b/crypten/mpc/primitives/converters.py
@@ -7,7 +7,7 @@
 
 import crypten.communicator as comm
 import torch
-from crypten.encoder import FixedPointEncoder
+from crypten.encoder import get_default_encoder
 
 from ..ptype import ptype as Ptype
 from . import beaver
@@ -46,7 +46,7 @@ def _B2A(binary_tensor, precision=None, bits=None):
             multiplier = multiplier.unsqueeze(1)
         arithmetic_tensor = arithmetic_bits.mul_(multiplier).sum(0)
 
-    arithmetic_tensor.encoder = FixedPointEncoder(precision_bits=precision)
+    arithmetic_tensor.encoder = get_default_encoder()(precision_bits=precision)
     scale = arithmetic_tensor.encoder._scale // binary_tensor.encoder._scale
     arithmetic_tensor *= scale
     return arithmetic_tensor

--- a/crypten/mpc/provider/ttp_provider.py
+++ b/crypten/mpc/provider/ttp_provider.py
@@ -14,7 +14,7 @@ import torch
 import torch.distributed as dist
 from crypten.common.rng import generate_kbit_random_tensor, generate_random_ring_element
 from crypten.common.util import count_wraps
-from crypten.encoder import FixedPointEncoder
+from crypten.encoder import get_default_encoder
 from crypten.mpc.primitives import ArithmeticSharedTensor, BinarySharedTensor
 
 
@@ -301,7 +301,7 @@ class TTPServer:
 
     def rand(self, *sizes, encoder=None):
         if encoder is None:
-            encoder = FixedPointEncoder()  # use default precision
+            encoder = get_default_encoder()()  # use default precision
 
         r = encoder.encode(torch.rand(*sizes))
         r = r - self._get_additive_PRSS(sizes, remove_rank=True)

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -11,7 +11,7 @@ import unittest
 import crypten
 import torch
 from crypten.common.util import chebyshev_series
-from crypten.encoder import FixedPointEncoder, nearest_integer_division
+from crypten.encoder import FixedPointEncoder
 
 
 def get_test_tensor(max_value=10, float=False):
@@ -65,28 +65,6 @@ class TestCommon(unittest.TestCase):
             tensor = torch.zeros(5, dtype=dtype).random_()
             decoded = fpe.decode(fpe.encode(tensor)).type(dtype)
             self._check(decoded, tensor, "Encoding/decoding a %s failed." % dtype)
-
-    def test_nearest_integer_division(self):
-        # test without scaling:
-        scale = 1
-        reference = [[-26, -25, -7, -5, -4, -1, 0, 1, 3, 4, 5, 7, 25, 26]]
-        tensor = torch.LongTensor(reference)
-        result = nearest_integer_division(tensor, scale)
-        self._check(
-            torch.LongTensor(result.tolist()),
-            torch.LongTensor(reference),
-            "Nearest integer division failed.",
-        )
-
-        # test with scaling:
-        scale = 4
-        reference = [[-6, -6, -2, -1, -1, 0, 0, 0, 1, 1, 1, 2, 6, 6]]
-        result = nearest_integer_division(tensor, scale)
-        self._check(
-            torch.LongTensor(result.tolist()),
-            torch.LongTensor(reference),
-            "Nearest integer division failed.",
-        )
 
     def test_chebyshev_series(self):
         """Checks coefficients returned by chebyshev_series are correct"""


### PR DESCRIPTION
Summary:
This diff is in response to https://github.com/facebookresearch/CrypTen/issues/57

It is unclear whether all of the API choices here are good. We had always planned on making encoders modular like this, but given that a lot of the arithmetic code assumes fixed point with scaling, it is unclear whether other encoders can be supported using the same API.

Additionally tests seem to run somewhat slower, but this is likely intermittent.

Differential Revision: D20008428

