### PR TITLE
Cleaner traceback formatting / logging

### DIFF
--- a/test/test_arithmetic.py
+++ b/test/test_arithmetic.py
@@ -50,7 +50,7 @@ class TestArithmetic(MultiProcessTestCase):
         test_passed = test_passed.gt(0).all().item() == 1
         if not test_passed:
             logging.info(msg)
-            logging.info("Result = %s;\nreference = %s" % (tensor, reference))
+            logging.info("Result - Reference = %s" % (tensor - reference))
         self.assertTrue(test_passed, msg=msg)
 
     def test_share_attr(self):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -48,7 +48,7 @@ class TestAutograd(object):
             test_passed = (tensor == reference).all().item() == 1
         if not test_passed:
             logging.info(msg)
-            logging.info("Result = %s;\nreference = %s" % (tensor, reference))
+            logging.info("Result - Reference = %s" % (tensor - reference))
         self.assertTrue(test_passed, msg=msg)
 
     def test_non_differentiable_marking(self):

--- a/test/test_binary.py
+++ b/test/test_binary.py
@@ -42,7 +42,7 @@ class TestBinary(MultiProcessTestCase):
         test_passed = (tensor == reference).all().item() == 1
         if not test_passed:
             logging.info(msg)
-            logging.info("Result = %s;\nreference = %s" % (tensor, reference))
+            logging.info("Result - Reference = %s" % (tensor - reference))
         self.assertTrue(test_passed, msg=msg)
 
     def test_encrypt_decrypt(self):

--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -42,7 +42,7 @@ class TestMPC(object):
         test_passed = test_passed.gt(0).all().item() == 1
         if not test_passed:
             logging.info(msg)
-            logging.info("Result = %s;\nreference = %s" % (tensor, reference))
+            logging.info("Result - Reference = %s" % (tensor - reference))
         self.assertTrue(test_passed, msg=msg)
 
     def _check_tuple(self, encrypted_tuple, reference, msg, tolerance=None):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -43,7 +43,7 @@ class TestNN(object):
             test_passed = (tensor == reference).all().item() == 1
         if not test_passed:
             logging.info(msg)
-            logging.info("Result = %s;\nreference = %s" % (tensor, reference))
+            logging.info("Result - Reference = %s" % (tensor - reference))
         self.assertTrue(test_passed, msg=msg)
 
     def _compute_reference_parameters(self, init_name, reference, model, learning_rate):


### PR DESCRIPTION
Summary:
* changed logging in `_check` to display diff (result - reference) as opposed to both tensors
* removed unecessary backward in `test_dropout` since it never executes (and generates multiline logs). This is due to PyTorch backward not being valid.

Differential Revision: D20039608

