### PR TITLE
Add MPCTensor.from_shares

### DIFF
--- a/crypten/mpc/primitives/arithmetic.py
+++ b/crypten/mpc/primitives/arithmetic.py
@@ -172,7 +172,7 @@ class ArithmeticSharedTensor(object):
         return result
 
     def reveal(self, dst=None):
-        """Get plaintext without any downscaling"""
+        """Decrypts the tensor without any downscaling."""
         tensor = self.share.clone()
         if dst is None:
             return comm.get().all_reduce(tensor)
@@ -180,7 +180,7 @@ class ArithmeticSharedTensor(object):
             return comm.get().reduce(tensor, dst=dst)
 
     def get_plain_text(self, dst=None):
-        """Decrypt the tensor"""
+        """Decrypts the tensor."""
         # Edge case where share becomes 0 sized (e.g. result of split)
         if self.nelement() < 1:
             return torch.empty(self.share.size())


### PR DESCRIPTION
Summary:
This diff adds a static `MPCTensor.from_shares` function that allows for the creation of an `MPCTensor` from private shares. This is a first step towards adding a `crypten.nn.Module.from_shares` function, which I will add in a subsequent diff.

The diff also adds the `MPCTensor.reveal` function that was apparently missing.

Differential Revision: D20184603

