### PR TITLE
Fix `conv2d` and `conv1d` stress test timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ setup_venv: &setup_venv
     python3 -m venv ~/crypten-test
     . ~/crypten-test/bin/activate
     pip3 install --upgrade pip
-    pip3 install onnx==1.6.0 tensorboard
+    pip3 install onnx==1.6.0 tensorboard parameterized
     pip3 install torch==1.5.0.dev20200220+cpu torchvision==0.6.0.dev20200220+cpu -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
 

--- a/test/test_arithmetic.py
+++ b/test/test_arithmetic.py
@@ -19,6 +19,7 @@ from crypten.common.rng import generate_random_ring_element
 from crypten.common.tensor_types import is_float_tensor
 from crypten.common.util import count_wraps
 from crypten.mpc.primitives import ArithmeticSharedTensor
+from parameterized import parameterized
 
 
 class TestArithmetic(MultiProcessTestCase):
@@ -433,10 +434,18 @@ class TestArithmetic(MultiProcessTestCase):
                     encrypted_out = encrypted_tensor.transpose(dim0, dim1)
                     self._check(encrypted_out, reference, "transpose failed")
 
-    def test_conv1d(self):
-        """Test convolution of encrypted tensor with public/private tensors."""
-        signal_sizes = [5, 32]
+    @staticmethod
+    def _conv1d_cases():
+        """Generates inputs tuples for test cases
+        Returns: list of parameters for test_conv1d test case
+        """
+        signal_sizes = [5, 16]
         nbatches = [1, 3, 5]
+        return itertools.product(signal_sizes, nbatches)
+
+    @parameterized.expand(_conv1d_cases.__func__)
+    def test_conv1d(self, signal_size, batches):
+        """Test convolution of encrypted tensor with public/private tensors."""
         ichannels = [1, 5]
 
         kernel_sizes = [1, 2, 3]
@@ -446,21 +455,13 @@ class TestArithmetic(MultiProcessTestCase):
         for func_name in ["conv1d", "conv_transpose1d"]:
             for kernel_type in [lambda x: x, ArithmeticSharedTensor]:
                 for (
-                    signal_size,
-                    batches,
                     in_channels,
                     kernel_size,
                     out_channels,
                     padding,
                     stride,
                 ) in itertools.product(
-                    signal_sizes,
-                    nbatches,
-                    ichannels,
-                    kernel_sizes,
-                    ochannels,
-                    paddings,
-                    strides,
+                    ichannels, kernel_sizes, ochannels, paddings, strides
                 ):
                     input_size = (batches, in_channels, signal_size)
                     signal = get_random_test_tensor(size=input_size, is_float=True)
@@ -482,10 +483,18 @@ class TestArithmetic(MultiProcessTestCase):
 
                     self._check(encrypted_conv, reference, f"{func_name} failed")
 
-    def test_conv2d(self):
-        """Test convolution of encrypted tensor with public/private tensors."""
+    @staticmethod
+    def _conv2d_cases():
+        """Generates inputs tuples for test cases
+        Returns: list of parameters for test_conv2d test case
+        """
         image_sizes = [(5, 5), (16, 7)]
         nbatches = [1, 3, 5]
+        return itertools.product(image_sizes, nbatches)
+
+    @parameterized.expand(_conv2d_cases.__func__)
+    def test_conv2d(self, image_size, batches):
+        """Test convolution of encrypted tensor with public/private tensors."""
         ichannels = [1, 5]
 
         kernel_sizes = [(1, 1), (2, 2), (2, 3)]
@@ -495,21 +504,13 @@ class TestArithmetic(MultiProcessTestCase):
         for func_name in ["conv2d", "conv_transpose2d"]:
             for kernel_type in [lambda x: x, ArithmeticSharedTensor]:
                 for (
-                    image_size,
-                    batches,
                     in_channels,
                     kernel_size,
                     out_channels,
                     padding,
                     stride,
                 ) in itertools.product(
-                    image_sizes,
-                    nbatches,
-                    ichannels,
-                    kernel_sizes,
-                    ochannels,
-                    paddings,
-                    strides,
+                    ichannels, kernel_sizes, ochannels, paddings, strides
                 ):
 
                     # sample input:

--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -20,6 +20,7 @@ from crypten.common.rng import generate_kbit_random_tensor, generate_random_ring
 from crypten.common.tensor_types import is_float_tensor
 from crypten.mpc import MPCTensor, ptype as Ptype
 from crypten.mpc.primitives import ArithmeticSharedTensor, BinarySharedTensor
+from parameterized import parameterized
 
 
 class TestMPC(object):
@@ -403,34 +404,34 @@ class TestMPC(object):
                     encrypted_out = encrypted_tensor.transpose(dim0, dim1)
                     self._check(encrypted_out, reference, "transpose failed")
 
-    def test_conv1d(self):
-        """Test convolution of encrypted tensor with public/private tensors."""
-        signal_sizes = [5, 32]
+    @staticmethod
+    def _conv1d_cases():
+        """Generates inputs tuples for test cases
+        Returns: list of parameters for test_conv1d test case
+        """
+        signal_sizes = [5, 16]
         nbatches = [1, 3, 5]
-        ichannels = [1, 5]
+        return itertools.product(signal_sizes, nbatches)
 
+    @parameterized.expand(_conv1d_cases.__func__)
+    def test_conv1d(self, signal_size, batches):
+        """Test convolution of encrypted tensor with public/private tensors."""
+        ichannels = [1, 5]
         kernel_sizes = [1, 2, 3]
         ochannels = [1, 3, 6]
         paddings = [0, 1]
         strides = [1, 2]
+
         for func_name in ["conv1d", "conv_transpose1d"]:
             for kernel_type in [lambda x: x, MPCTensor]:
                 for (
-                    signal_size,
-                    batches,
                     in_channels,
                     kernel_size,
                     out_channels,
                     padding,
                     stride,
                 ) in itertools.product(
-                    signal_sizes,
-                    nbatches,
-                    ichannels,
-                    kernel_sizes,
-                    ochannels,
-                    paddings,
-                    strides,
+                    ichannels, kernel_sizes, ochannels, paddings, strides
                 ):
                     input_size = (batches, in_channels, signal_size)
                     signal = get_random_test_tensor(size=input_size, is_float=True)
@@ -452,34 +453,34 @@ class TestMPC(object):
 
                     self._check(encrypted_conv, reference, f"{func_name} failed")
 
-    def test_conv2d(self):
-        """Test convolution of encrypted tensor with public/private tensors."""
+    @staticmethod
+    def _conv2d_cases():
+        """Generates inputs tuples for test cases
+        Returns: list of parameters for test_conv2d test case
+        """
         image_sizes = [(5, 5), (16, 7)]
         nbatches = [1, 3, 5]
-        ichannels = [1, 5]
+        return itertools.product(image_sizes, nbatches)
 
+    @parameterized.expand(_conv2d_cases.__func__)
+    def test_conv2d(self, image_size, batches):
+        """Test convolution of encrypted tensor with public/private tensors."""
+        ichannels = [1, 5]
         kernel_sizes = [(1, 1), (2, 2), (2, 3)]
         ochannels = [1, 3, 6]
         paddings = [0, 1, (0, 1)]
         strides = [1, 2, (1, 2)]
+
         for func_name in ["conv2d", "conv_transpose2d"]:
             for kernel_type in [lambda x: x, MPCTensor]:
                 for (
-                    image_size,
-                    batches,
                     in_channels,
                     kernel_size,
                     out_channels,
                     padding,
                     stride,
                 ) in itertools.product(
-                    image_sizes,
-                    nbatches,
-                    ichannels,
-                    kernel_sizes,
-                    ochannels,
-                    paddings,
-                    strides,
+                    ichannels, kernel_sizes, ochannels, paddings, strides
                 ):
 
                     # sample input:


### PR DESCRIPTION
Summary:
Re-enables tests for conv2d and conv1d by preventing stress test time outs.

Verified gradients for conv1d and conv2d are correct. Convolution tests were disabled due to timeouts (see stress test https://our.intern.facebook.com/intern/test/281474992028520?ref_report_id=0). This diff separates test cases using `parameterize.expand` to parallelize conv tests thereby preventing stress test timeouts.

Differential Revision: D20240430

