### PR TITLE
Implement and utilize bradcast_obj for crypten.load

### DIFF
--- a/test/test_communicator.py
+++ b/test/test_communicator.py
@@ -178,6 +178,23 @@ class TestCommunicator:
                 self.assertTrue(torch.is_tensor(tensor))
                 self.assertTrue(tensor.eq(1).all())
 
+    def test_send_recv_obj(self):
+        reference = {"a": 1, "b": 2, "c": 3}
+        for src in range(self.world_size):
+            if self.rank == src:
+                test_obj = reference
+                comm.get().send_obj(test_obj, 1 - self.rank)
+            else:
+                test_obj = comm.get().recv_obj(1 - self.rank)
+            self.assertEqual(test_obj, reference, "send/recv_obj failed")
+
+    def test_broadcast_obj(self):
+        reference = {"a": 1, "b": 2, "c": 3}
+        for src in range(self.world_size):
+            test_obj = reference if self.rank == src else None
+            test_obj = comm.get().broadcast_obj(test_obj, src)
+            self.assertEqual(test_obj, reference, "broadcast_obj failed")
+
 
 # TODO: Commenting this out until we figure out why `thread.join() hangs
 #       Perhaps the thread to be joined has somehow exited

--- a/test/test_crypten.py
+++ b/test/test_crypten.py
@@ -172,23 +172,13 @@ class TestCrypten(MultiProcessTestCase):
             for src in range(comm.get().get_world_size()):
                 crypten.save(test_model, filename, src=src)
 
-                dummy_model = model_type(200, 10)
-
-                result = crypten.load(filename, dummy_model=dummy_model, src=src)
+                result = crypten.load(filename, src=src)
                 if src == rank:
                     for param in result.parameters(recurse=True):
                         self.assertTrue(
                             param.eq(rank).all().item(), "Model load failed"
                         )
                 self.assertEqual(result.src, src)
-
-                failure_dummy_model = model_type(200, 11)
-                with self.assertRaises(
-                    AssertionError, msg="Expected load failure not raised"
-                ):
-                    result = crypten.load(
-                        filename, dummy_model=failure_dummy_model, src=src
-                    )
 
     def test_where(self):
         """Test that crypten.where properly conditions"""


### PR DESCRIPTION
Summary: Implemented broadcast_obj to broadcast an object and used it to simplify crypten.load. Also added / adjusted tests accordingly.

Reviewed By: vshobha

Differential Revision: D20500455

