### PR TITLE
Add state_dict logic to crypten.nn.Module

### DIFF
--- a/crypten/cryptensor.py
+++ b/crypten/cryptensor.py
@@ -309,6 +309,10 @@ class CrypTensor(object, metaclass=CrypTensorMetaclass):
         # TODO: Rename this to __copy__()?
         raise NotImplementedError("shallow_copy is not implemented")
 
+    def copy_(self, other):
+        """Copies value of other CrypTensor into this CrypTensor."""
+        raise NotImplementedError("copy_ is not implemented")
+
     def add_(self, tensor):
         """Adds :attr:`tensor` to :attr:`self` (in-place) see :meth:`add`."""
         raise NotImplementedError("add_ is not implemented")

--- a/crypten/mpc/mpc.py
+++ b/crypten/mpc/mpc.py
@@ -110,6 +110,12 @@ class MPCTensor(CrypTensor):
         result.ptype = self.ptype
         return result
 
+    def copy_(self, other):
+        """Copies value of other MPCTensor into this MPCTensor."""
+        assert isinstance(other, MPCTensor), "other must be MPCTensor"
+        self._tensor.copy_(other._tensor)
+        self.ptype = other.ptype
+
     # Handle share types and conversions
     def to(self, ptype, **kwargs):
         """Converts self._tensor to the given ptype

--- a/crypten/mpc/primitives/arithmetic.py
+++ b/crypten/mpc/primitives/arithmetic.py
@@ -101,6 +101,11 @@ class ArithmeticSharedTensor(object):
         result.share = self.share
         return result
 
+    def copy_(self, other):
+        """Copies other tensor into this tensor."""
+        self.share.copy_(other.share)
+        self.encoder = other.encoder
+
     def __repr__(self):
         return f"ArithmeticSharedTensor({self.share})"
 

--- a/crypten/mpc/primitives/binary.py
+++ b/crypten/mpc/primitives/binary.py
@@ -5,8 +5,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from functools import reduce
-
 import crypten.communicator as comm
 
 # dependencies:
@@ -97,6 +95,11 @@ class BinarySharedTensor(object):
         result.encoder = self.encoder
         result.share = self.share
         return result
+
+    def copy_(self, other):
+        """Copies other tensor into this tensor."""
+        self.share.copy_(other.share)
+        self.encoder = other.encoder
 
     def __repr__(self):
         return f"BinarySharedTensor({self.share})"

--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -1288,6 +1288,17 @@ class TestMPC(object):
             )
             self._check(encrypted_tensor_clone, tensor, "clone failed")
 
+    def test_copy_(self):
+        """Tests copy_ function."""
+        sizes = [(5,), (1, 5), (5, 10, 15)]
+        for size in sizes:
+            tensor1 = get_random_test_tensor(size=size, is_float=True)
+            tensor2 = get_random_test_tensor(size=size, is_float=True)
+            encrypted_tensor1 = MPCTensor(tensor1)
+            encrypted_tensor2 = MPCTensor(tensor2)
+            encrypted_tensor1.copy_(encrypted_tensor2)
+            self._check(encrypted_tensor1, tensor2, "copy_ failed")
+
     def test_index_select(self):
         """Tests index_select of encrypted tensors."""
         sizes = [(5,), (5, 10), (5, 10, 15)]

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -991,6 +991,106 @@ class TestNN(object):
             _run_test(sample, target)
             _run_test(crypten.cryptensor(sample), crypten.cryptensor(target))
 
+    def test_state_dict(self):
+        """
+        Tests dumping and loading of state dicts.
+        """
+
+        def _check_equal(t1, t2):
+            """
+            Checks whether to tensors are identical.
+            """
+            if isinstance(t1, torch.nn.parameter.Parameter):
+                t1 = t1.data
+            if isinstance(t2, torch.nn.parameter.Parameter):
+                t2 = t2.data
+            self.assertEqual(type(t1), type(t2))
+            if isinstance(t1, crypten.CrypTensor):
+                t1 = t1.get_plain_text()
+                t2 = t2.get_plain_text()
+            self.assertTrue(t1.eq(t2).all())
+
+        def _check_state_dict(model, state_dict):
+            """
+            Checks if state_dict matches parameters in model.
+            """
+            print(model)
+
+            # get all parameters, buffers, and names from model:
+            params_buffers = {}
+            for func in ["named_parameters", "named_buffers"]:
+                params_buffers.update({k: v for k, v in getattr(model, func)()})
+
+            # do all the checks:
+            self.assertEqual(len(params_buffers), len(state_dict))
+            for name, param_or_buffer in params_buffers.items():
+                self.assertIn(name, state_dict)
+                _check_equal(state_dict[name], param_or_buffer)
+
+        # test for individual modules:
+        module_args = {
+            "BatchNorm1d": (400,),
+            "BatchNorm2d": (3,),
+            "BatchNorm3d": (6,),
+            "Conv1d": (3, 6, 5),
+            "Conv2d": (3, 6, 5),
+            "Linear": (400, 120),
+        }
+        for module_name, args in module_args.items():
+            for encrypt in [False, True]:
+
+                # create module and get state dict:
+                module = getattr(crypten.nn, module_name)(*args)
+                if encrypt:
+                    module.encrypt()
+                state_dict = module.state_dict()
+                _check_state_dict(module, state_dict)
+
+                # load state dict into fresh module:
+                new_module = getattr(crypten.nn, module_name)(*args)
+                if encrypt:
+                    with self.assertRaises(AssertionError):
+                        new_module.load_state_dict(state_dict)
+                    new_module.encrypt()
+                new_module.load_state_dict(state_dict)
+                _check_state_dict(new_module, state_dict)
+
+        # tests for model that is sequence of modules:
+        for num_layers in range(1, 6):
+            for encrypt in [False, True]:
+
+                # some variables that we need:
+                input_size = (3, 10)
+                output_size = (input_size[0], input_size[1] - num_layers)
+                layer_idx = range(input_size[1], output_size[1], -1)
+
+                # construct sequential model:
+                module_list = [
+                    crypten.nn.Linear(num_feat, num_feat - 1) for num_feat in layer_idx
+                ]
+                model = crypten.nn.Sequential(module_list)
+                if encrypt:
+                    model.encrypt()
+
+                # check state dict:
+                state_dict = model.state_dict()
+                _check_state_dict(model, state_dict)
+
+                # load state dict into fresh model:
+                state_dict = model.state_dict()
+                module_list = [
+                    crypten.nn.Linear(num_feat, num_feat - 1) for num_feat in layer_idx
+                ]
+                new_model = crypten.nn.Sequential(module_list)
+                if encrypt:
+                    with self.assertRaises(AssertionError):
+                        new_model.load_state_dict(state_dict)
+                    new_model.encrypt()
+                new_model.load_state_dict(state_dict)
+
+                # check new model:
+                _check_state_dict(model, state_dict)
+
 
 # Run all unit tests with both TFP and TTP providers
 class TestTFP(MultiProcessTestCase, TestNN):


### PR DESCRIPTION
Summary:
This diff implements `state_dict()` and `load_state_dict()` functions in `crypten.nn.Module` that work in the same way as their PyTorch counterparts. This will make serialization of models easier: as long as `CrypTensor`s are serializable, the `state_dict` will be a serializable object that can be pickled directly.

This diff also adds the `CrypTensor.copy_()` function, which was still missing from the `CrypTensor` API.

Differential Revision: D20603904

