### PR TITLE
Add missing unit tests for BinarySharedTensor scatter / gather

### DIFF
--- a/crypten/mpc/primitives/binary.py
+++ b/crypten/mpc/primitives/binary.py
@@ -329,7 +329,7 @@ class BinarySharedTensor(object):
         corresponding value in `index` for `dimension = dim`.
         """
         result = self.clone()
-        return result.scatter_(self, dim, index, src)
+        return result.scatter_(dim, index, src)
 
     # Bitwise operators
     __add__ = add
@@ -365,7 +365,6 @@ REGULAR_FUNCTIONS = [
     "flip",
     "reshape",
     "gather",
-    "scatter",
     "take",
     "split",
 ]

--- a/test/test_arithmetic.py
+++ b/test/test_arithmetic.py
@@ -880,10 +880,36 @@ class TestArithmetic(MultiProcessTestCase):
                 encrypted_out = encrypted.gather(dim, index)
                 self._check(encrypted_out, reference, f"gather failed with size {size}")
 
-    # TODO: Write the following unit tests
-    @unittest.skip("Test not implemented")
     def test_split(self):
-        pass
+        """Test gather function of encrypted tensor"""
+        sizes = [(5, 5), (5, 5, 5), (5, 5, 5, 5)]
+
+        for size in sizes:
+            for dim in range(len(size)):
+                tensor = get_random_test_tensor(size=size, is_float=True)
+                encrypted = ArithmeticSharedTensor(tensor)
+
+                for idx in range(6):
+                    split = (idx, 5 - idx)
+                    reference0, reference1 = tensor.split(split, dim=dim)
+                    encrypted_out0, encrypted_out1 = encrypted.split(split, dim=dim)
+
+                    self._check(
+                        encrypted_out0, reference0, f"split failed with input {split}"
+                    )
+                    self._check(
+                        encrypted_out1, reference1, f"split failed with input {split}"
+                    )
+
+                split = (5,)
+                reference, = tensor.split(split, dim=dim)
+                encrypted_out, = encrypted.split(split, dim=dim)
+                self._check(
+                    encrypted_out, reference, f"split failed with input {split}"
+                )
+
+                with self.assertRaises(RuntimeError):
+                    encrypted_out.split((5, 1))
 
 
 # This code only runs when executing the file outside the test harness

--- a/test/test_arithmetic.py
+++ b/test/test_arithmetic.py
@@ -333,11 +333,11 @@ class TestArithmetic(MultiProcessTestCase):
                             "%s %s failed" % ("private" if private else "public", func),
                         )
                         if func.endswith("_"):
-                            # Check in-place scatter/scatter-add worked
+                            # Check in-place scatter/scatter-add modified input
                             self._check(
                                 encrypted,
                                 reference,
-                                "%s %s failed"
+                                "%s %s failed to modify input"
                                 % ("private" if private else "public", func),
                             )
                         else:
@@ -345,7 +345,7 @@ class TestArithmetic(MultiProcessTestCase):
                             self._check(
                                 encrypted,
                                 tensor1,
-                                "%s %s failed"
+                                "%s %s unintendedly modified input"
                                 % ("private" if private else "public", func),
                             )
 

--- a/test/test_binary.py
+++ b/test/test_binary.py
@@ -397,9 +397,36 @@ class TestBinary(MultiProcessTestCase):
     def test_gather_scatter(self):
         pass
 
-    @unittest.skip("Test not implemented")
     def test_split(self):
-        pass
+        """Test gather function of encrypted tensor"""
+        sizes = [(5, 5), (5, 5, 5), (5, 5, 5, 5)]
+
+        for size in sizes:
+            for dim in range(len(size)):
+                tensor = get_random_test_tensor(size=size, is_float=False)
+                encrypted = BinarySharedTensor(tensor)
+
+                for idx in range(6):
+                    split = (idx, 5 - idx)
+                    reference0, reference1 = tensor.split(split, dim=dim)
+                    encrypted_out0, encrypted_out1 = encrypted.split(split, dim=dim)
+
+                    self._check(
+                        encrypted_out0, reference0, f"split failed with input {split}"
+                    )
+                    self._check(
+                        encrypted_out1, reference1, f"split failed with input {split}"
+                    )
+
+                split = (5,)
+                reference, = tensor.split(split, dim=dim)
+                encrypted_out, = encrypted.split(split, dim=dim)
+                self._check(
+                    encrypted_out, reference, f"split failed with input {split}"
+                )
+
+                with self.assertRaises(RuntimeError):
+                    encrypted_out.split((5, 1))
 
 
 # This code only runs when executing the file outside the test harness


### PR DESCRIPTION
Summary:
Added unit tests for scatter / gather in BinarySharedTensor and fixed 2 bugs:
- removed scatter from REGULAR_FUNCTIONS in binary.py
- removed extra `self` argument from out-of-place scatter (semantic error)

Differential Revision: D20793863

