### PR TITLE
Add party names (#200)

### DIFF
--- a/crypten/__init__.py
+++ b/crypten/__init__.py
@@ -26,8 +26,15 @@ enable_grad = CrypTensor.enable_grad
 set_grad_enabled = CrypTensor.set_grad_enabled
 
 
-def init():
+def init(party_name=None):
+    # Initialize communicator
     comm._init(use_threads=False, init_ttp=crypten.mpc.ttp_required())
+
+    # Setup party name for file save / load
+    if party_name is not None:
+        comm.get().set_name(party_name)
+
+    # Setup seeds for Random Number Generation
     if comm.get().get_rank() < comm.get().get_world_size():
         _setup_przs()
         if crypten.mpc.ttp_required():

--- a/crypten/communicator/communicator.py
+++ b/crypten/communicator/communicator.py
@@ -104,6 +104,14 @@ class Communicator:
         """Returns the rank of the current process."""
         raise NotImplementedError("get_rank is not implemented")
 
+    def set_name(self):
+        """Sets the party name of the current process."""
+        raise NotImplementedError("set_name is not implemented")
+
+    def get_name(self):
+        """Returns the party name of the current process."""
+        raise NotImplementedError("get_name is not implemented")
+
     def reset_communication_stats(self):
         """Resets communication statistics."""
         raise NotImplementedError("reset_communication_stats is not implemented")

--- a/crypten/communicator/distributed_communicator.py
+++ b/crypten/communicator/distributed_communicator.py
@@ -40,6 +40,7 @@ class DistributedCommunicator(Communicator):
             self.world_size = int(self.world_size)
             self.rank = int(self.rank)
             self.reset_communication_stats()
+            self.name = f"rank{self.rank}"
 
             # logging:
             logging.info("==================")
@@ -310,6 +311,17 @@ class DistributedCommunicator(Communicator):
     def get_ttp_rank(self):
         """Returns the rank of the Trusted Third Party"""
         return self.get_world_size()
+
+    def set_name(self, name):
+        """Sets the party name of the current process."""
+        assert isinstance(
+            name, str
+        ), f"Improper name provided to process on rank {self.get_rank()}"
+        self.name = name
+
+    def get_name(self):
+        """Returns the party name of the current process."""
+        return self.name
 
     def get_distributed_backend(self):
         """Returns name of torch.distributed backend used."""

--- a/test/test_communicator.py
+++ b/test/test_communicator.py
@@ -215,6 +215,25 @@ class TestCommunicator:
             test_obj = comm.get().broadcast_obj(test_obj, src)
             self.assertEqual(test_obj, reference, "broadcast_obj failed")
 
+    def test_name(self):
+        # Test default name is correct
+        self.assertEqual(comm.get().get_name(), f"rank{comm.get().get_rank()}")
+
+        # Test name set / get
+        comm.get().set_name(f"{comm.get().get_rank()}")
+        self.assertEqual(comm.get().get_name(), f"{comm.get().get_rank()}")
+
+        # Test initialization using crypten.init()
+        name = f"init_{comm.get().get_rank()}"
+        crypten.uninit()
+        crypten.init(party_name=name)
+        self.assertEqual(comm.get().get_name(), f"init_{comm.get().get_rank()}")
+
+        # Test failure on bad input
+        for improper_input in [0, None, ["name"], ("name",)]:
+            with self.assertRaises(AssertionError):
+                comm.get().set_name(improper_input)
+
 
 # TODO: Commenting this out until we figure out why `thread.join() hangs
 #       Perhaps the thread to be joined has somehow exited


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/fairinternal/CrypTen/pull/200

Added the ability to name each party using `comm.get().set_name(name)` or `crypten.init(party_name=name)`. Party names are then retrievable using `comm.get().get_name()`.

Added test for all cases of setting / getting names in `test_communicator.py`.

Reviewed By: marksibrahim

Differential Revision: D21020370

