### PR TITLE
Suppress tensorflow warnings in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ setup_venv: &setup_venv
     pip3 install torch==1.6.0.dev20200410+cpu torchvision==0.6.0.dev20200410+cpu -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     pip3 install tensorflow
     pip3 install git+https://github.com/onnx/tensorflow-onnx.git@557939b6eb07a122e74009b8ecd6d1d0cef0b94b
+  environment:
+    # suppress tensorflow GPU warnings
+    TF_CPP_MIN_LOG_LEVEL: "2"
 
 
 # -------------------------------------------------------------------------------------

--- a/crypten/nn/__init__.py
+++ b/crypten/nn/__init__.py
@@ -68,6 +68,7 @@ try:
     import tensorflow as tf  # noqa
     import tf2onnx
 
+    tf.logging.set_verbosity(tf.logging.ERROR)
     TF_AND_TF2ONNX = True
 except ImportError:
     TF_AND_TF2ONNX = False


### PR DESCRIPTION
Summary:
Suppresses tensorflow warnings that riddle the circle ci unit test logs. The warnings are related to the lack of GPU support and are unnecessary for our purposes.

Thank to vshobha for finding the environment variable to suppress these warnings.

Differential Revision: D21079616

