### PR TITLE
Fix crypten.load which is returning None

### DIFF
--- a/crypten/__init__.py
+++ b/crypten/__init__.py
@@ -310,7 +310,7 @@ def load(
         "'load_from_party' function instead.",
         DeprecationWarning,
     )
-    load_from_party(f, preloaded, encrypted, dummy_model, src, load_closure, **kwargs)
+    return load_from_party(f, preloaded, encrypted, dummy_model, src, load_closure, **kwargs)
 
 
 def save_from_party(obj, f, src=0, save_closure=torch.save, **kwargs):


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

`crypten.load` was wrapping the newer function `crypten.load_from_party` but wasn't returning the result of that function.

## How Has This Been Tested (if it applies)

Tutorial7 wasn't running because `crypten.load` was returning `None`, now it works.

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
