### PR TITLE
use set_() instead of setting .data directly

### DIFF
--- a/crypten/mpc/primitives/arithmetic.py
+++ b/crypten/mpc/primitives/arithmetic.py
@@ -250,9 +250,9 @@ class ArithmeticSharedTensor(object):
             else:  # ['mul', 'matmul', 'convNd', 'conv_transposeNd']
                 # NOTE: 'mul_' calls 'mul' here
                 # Must copy share.data here to support 'mul_' being inplace
-                result.share.data = getattr(beaver, op)(
-                    result, y, *args, **kwargs
-                ).share.data
+                result.share.set_(getattr(beaver, op)(
+                    result, y, *args, **kwargs).share.data
+                )
         else:
             raise TypeError("Cannot %s %s with %s" % (op, type(y), type(self)))
 

--- a/crypten/mpc/primitives/binary.py
+++ b/crypten/mpc/primitives/binary.py
@@ -139,7 +139,7 @@ class BinarySharedTensor(object):
         if torch.is_tensor(y) or isinstance(y, int):
             self.share &= y
         elif isinstance(y, BinarySharedTensor):
-            self.share.data = beaver.AND(self, y).share.data
+            self.share.set_(beaver.AND(self, y).share.data)
         else:
             raise TypeError("Cannot AND %s with %s." % (type(y), type(self)))
         return self


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

There is an issue with setting a torch tensor using the `.data` attribute [here](https://github.com/facebookresearch/CrypTen/blob/master/crypten/mpc/primitives/arithmetic.py#L253) and [here](https://github.com/facebookresearch/CrypTen/blob/master/crypten/mpc/primitives/binary.py#L142), those lines are throwing an `AttributeError: can't set attribute`. My use-case uses PySyft which might be the cause of throwing that error but I believe that using `.set_` instead won't affect the current implementation. I got the fix from a related issue pytorch/pytorch#30987

## How Has This Been Tested (if it applies)

A complete training of the same model in Tutorial7.

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
