### PR TITLE
Binary comparators and API update

### DIFF
--- a/crypten/mpc/mpc.py
+++ b/crypten/mpc/mpc.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import warnings
 from dataclasses import dataclass
 from functools import wraps
 
@@ -16,7 +15,6 @@ from crypten.common.util import ConfigBase, pool_reshape
 
 from ..cryptensor import CrypTensor
 from .max_helper import _argmax_helper, _max_helper_all_tree_reductions
-from .primitives import circuit
 from .primitives.converters import convert
 from .ptype import ptype as Ptype
 
@@ -419,17 +417,24 @@ class MPCTensor(CrypTensor):
     def eq(self, y, _scale=True):
         """Returns self == y"""
         if comm.get().get_world_size() == 2:
-            return (self - y)._eqz(_scale=_scale)
+            return (self - y)._eqz_2PC(_scale=_scale)
 
         return 1 - self.ne(y, _scale=_scale)
 
     @mode(Ptype.arithmetic)
-    def _eqz(self, _scale=True):
+    def _eqz_2PC(self, _scale=True):
         """Returns self == 0"""
+        # Create BinarySharedTensors from shares
         x0 = MPCTensor(self.share, src=0, ptype=Ptype.binary)
         x1 = MPCTensor(-self.share, src=1, ptype=Ptype.binary)
 
-        result = circuit.eqz_helper_tree_reduction(x0, x1)
+        # Perform equality testing using binary shares
+        x0._tensor = x0._tensor.eq(x1._tensor)
+
+        # Convert to Arithmetic sharing
+        result = x0.to(Ptype.arithmetic, bits=1)
+
+        # Handle scaling
         if _scale:
             return result * result.encoder._scale
         else:

--- a/crypten/mpc/primitives/binary.py
+++ b/crypten/mpc/primitives/binary.py
@@ -197,6 +197,24 @@ class BinarySharedTensor(object):
         """Compute [self] + [y] for xor-sharing"""
         return circuit.add(self, y)
 
+    def eq(self, y):
+        return circuit.eq(self, y)
+
+    def ne(self, y):
+        return self.eq(y) ^ 1
+
+    def lt(self, y):
+        return circuit.lt(self, y)
+
+    def le(self, y):
+        return circuit.le(self, y)
+
+    def gt(self, y):
+        return circuit.gt(self, y)
+
+    def ge(self, y):
+        return circuit.ge(self, y)
+
     def __setitem__(self, index, value):
         """Set tensor values by index"""
         if torch.is_tensor(value) or isinstance(value, list):
@@ -336,6 +354,12 @@ class BinarySharedTensor(object):
 
     # Bitwise operators
     __add__ = add
+    __eq__ = eq
+    __ne__ = ne
+    __lt__ = lt
+    __le__ = le
+    __gt__ = gt
+    __ge__ = ge
     __lshift__ = lshift
     __rshift__ = rshift
 

--- a/test/test_binary.py
+++ b/test/test_binary.py
@@ -229,7 +229,23 @@ class TestBinary(MultiProcessTestCase):
             encrypted_tensor = BinarySharedTensor(tensor)
             encrypted_tensor2 = tensor_type(tensor2)
             encrypted_out = encrypted_tensor + encrypted_tensor2
-            self._check(encrypted_out, reference, "%s AND failed" % tensor_type)
+            self._check(encrypted_out, reference, "%s add failed" % tensor_type)
+
+    def test_comparators(self):
+        """Test comparators (>, >=, <, <=, ==, !=)"""
+        for _scale in [False, True]:
+            for comp in ["gt", "ge", "lt", "le", "eq", "ne"]:
+                for tensor_type in [lambda x: x, BinarySharedTensor]:
+                    tensor = get_random_test_tensor(is_float=False)
+                    tensor2 = get_random_test_tensor(is_float=False)
+
+                    encrypted_tensor = BinarySharedTensor(tensor)
+                    encrypted_tensor2 = tensor_type(tensor2)
+
+                    reference = getattr(tensor, comp)(tensor2).long()
+                    encrypted_out = getattr(encrypted_tensor, comp)(encrypted_tensor2)
+
+                    self._check(encrypted_out, reference, "%s comparator failed" % comp)
 
     def test_sum(self):
         """Tests sum using binary shares"""
@@ -495,8 +511,8 @@ class TestBinary(MultiProcessTestCase):
                     )
 
                 split = (5,)
-                reference, = tensor.split(split, dim=dim)
-                encrypted_out, = encrypted.split(split, dim=dim)
+                (reference,) = tensor.split(split, dim=dim)
+                (encrypted_out,) = encrypted.split(split, dim=dim)
                 self._check(
                     encrypted_out, reference, f"split failed with input {split}"
                 )


### PR DESCRIPTION
Summary:
Addressing API update re D21645199:

- Moved circuit call to binary.py
- _eq_2pc will now properly convert back to arithmetic sharing at the end
- Added eq comparator to BinarySharedTensor
- Renamed new circuit to __P_circuit to follow SPK naming convention

Also added comparators to `BinarySharedTensor` and `circuit` classes in case we need them in the future. These will be more efficient if we already have a `BinarySharedTensor` and want to do comparisons. Additionally, added tests for these new comparators in `test_binary.py`.

Differential Revision: D21663462

