### PR TITLE
Support logging communication time for Communicator

### DIFF
--- a/crypten/communicator/communicator.py
+++ b/crypten/communicator/communicator.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import time
 
 
 class Communicator:
@@ -128,17 +129,22 @@ class Communicator:
         """Resets communication statistics."""
         self.comm_rounds = 0
         self.comm_bytes = 0
+        self.comm_time = 0
 
     def print_communication_stats(self):
         """Prints communication statistics."""
         logging.info("====Communication Stats====")
-        logging.info("Rounds: %d" % self.comm_rounds)
-        logging.info("Bytes : %d" % self.comm_bytes)
+        logging.info("Rounds: {}".format(self.comm_rounds))
+        logging.info("Bytes : {}".format(self.comm_bytes))
+        logging.info("Comm time: {}".format(self.comm_time))
 
     def _log_communication(self, nelement):
         """Updates log of communication statistics."""
         self.comm_rounds += 1
         self.comm_bytes += nelement * self.BYTES_PER_ELEMENT
+
+    def _log_communication_time(self, comm_time):
+        self.comm_time += comm_time
 
 
 def _logging(func):
@@ -165,6 +171,13 @@ def _logging(func):
                 self._log_communication(nbytes)
             else:  # one tensor communicated
                 self._log_communication(args[0].nelement())
-        return func(self, *args, **kwargs)
+
+        tic = time.perf_counter()
+        result = func(self, *args, **kwargs)
+        toc = time.perf_counter()
+
+        self._log_communication_time(toc - tic)
+
+        return result
 
     return logging_wrapper


### PR DESCRIPTION
Summary: It is nice to record how much time is spent on communication so users can get a clearer sense of the time allocation between communication and computation.

Differential Revision: D21665446

