### PR TITLE
Upgrade torch version due to breaking change in ifloor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ setup_venv: &setup_venv
     . ~/crypten-test/bin/activate
     pip3 install --upgrade pip
     pip3 install onnx==1.6.0 tensorboard pandas sklearn
-    pip3 install torch==1.6.0.dev20200410+cpu torchvision==0.6.0.dev20200410+cpu -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    pip3 install torch==1.6.0.dev20200525+cpu torchvision==0.7.0.dev20200525+cpu -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     pip3 install tensorflow
     pip3 install git+https://github.com/onnx/tensorflow-onnx.git@557939b6eb07a122e74009b8ecd6d1d0cef0b94b
 


### PR DESCRIPTION
Summary: Upgrading version of pytorch we use in circle ci tests due to recent ifloor changes (see D21598179) that break unit tests ([circle ci failure](https://app.circleci.com/pipelines/github/facebookresearch/CrypTen/375/workflows/4fc36233-6503-44b3-903f-e9acecf2b43a/jobs/1463/steps)).

Differential Revision: D21687275

