### PR TITLE
Add masking to update_parameters

### DIFF
--- a/crypten/nn/module.py
+++ b/crypten/nn/module.py
@@ -259,9 +259,14 @@ class Module:
         for param in self.parameters():
             param.grad = None
 
-    def update_parameters(self, learning_rate):
+    def update_parameters(self, learning_rate, mask=None):
         """Performs gradient step on parameters."""
         assert self.training, "module not in training mode"
+
+        # Apply mask to gradient updates throught learning rate
+        if mask is not None:
+            learning_rate = mask * learning_rate
+
         with crypten.no_grad(), torch.no_grad():
             for param in self.parameters():
                 if param.grad is None:


### PR DESCRIPTION
Summary:
Added a masking kwarg to `update_parameters` in crypten.nn.Module

The mask allows for a one-time overwrite of the learning rate. This is useful to zero out the gradients for dummy inputs. (e.g. if we do a private match that returns unmatched rows, we can zero out the gradient updates for the unmatched rows by using an encrypted mask).

Differential Revision: D21723160

