### PR TITLE
Implement RSS for ArithmeticSharedTensor

### DIFF
--- a/crypten/mpc/primitives/resharing.py
+++ b/crypten/mpc/primitives/resharing.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import crypten.communicator as comm
+import torch
+
+
+def replicate_shares(x_share):
+    rank = comm.get().get_rank()
+    world_size = comm.get().get_world_size()
+    prev_rank = (rank - 1) % world_size
+    next_rank = (rank + 1) % world_size
+
+    x_rep = torch.zeros_like(x_share)
+
+    req0 = comm.get().isend(x_share, dst=next_rank)
+    req1 = comm.get().irecv(x_rep, src=prev_rank)
+
+    req0.wait()
+    req1.wait()
+
+    return x_rep
+
+
+def __replicated_secret_sharing_protocol(op, x, y, *args, **kwargs):
+    assert op in {
+        "mul",
+        "matmul",
+        "conv1d",
+        "conv2d",
+        "conv_transpose1d",
+        "conv_transpose2d",
+    }
+    from .arithmetic import ArithmeticSharedTensor
+    from .binary import BinarySharedTensor
+
+    x1, x2 = x.share, replicate_shares(x.share)
+    y1, y2 = y.share, replicate_shares(y.share)
+
+    z = getattr(torch, op)(x1, y1, *args, **kwargs)
+    z += getattr(torch, op)(x1, y2, *args, **kwargs)
+    z += getattr(torch, op)(x2, y1, *args, **kwargs)
+
+    rank = comm.get().get_rank()
+    if isinstance(x, BinarySharedTensor):
+        z = BinarySharedTensor.from_shares(z, src=rank)
+    elif isinstance(x, ArithmeticSharedTensor):
+        z = ArithmeticSharedTensor.from_shares(z, src=rank)
+
+    return z
+
+
+def mul(x, y):
+    return __replicated_secret_sharing_protocol("mul", x, y)
+
+
+def matmul(x, y):
+    return __replicated_secret_sharing_protocol("matmul", x, y)
+
+
+def conv1d(x, y, **kwargs):
+    return __replicated_secret_sharing_protocol("conv1d", x, y, **kwargs)
+
+
+def conv2d(x, y, **kwargs):
+    return __replicated_secret_sharing_protocol("conv2d", x, y, **kwargs)
+
+
+def conv_transpose1d(x, y, **kwargs):
+    return __replicated_secret_sharing_protocol("conv_transpose1d", x, y, **kwargs)
+
+
+def conv_transpose2d(x, y, **kwargs):
+    return __replicated_secret_sharing_protocol("conv_transpose2d", x, y, **kwargs)
+
+
+def square(x):
+    from .arithmetic import ArithmeticSharedTensor
+
+    x1, x2 = x.share, replicate_shares(x.share)
+    x_square = x1 ** 2 + 2 * x1 * x2
+
+    return ArithmeticSharedTensor.from_shares(x_square, src=comm.get().get_rank())

--- a/test/test_arithmetic.py
+++ b/test/test_arithmetic.py
@@ -51,6 +51,7 @@ class TestArithmetic(MultiProcessTestCase):
         if not test_passed:
             logging.info(msg)
             logging.info("Result %s" % tensor)
+            logging.info("Reference %s" % reference)
             logging.info("Result - Reference = %s" % (tensor - reference))
         self.assertTrue(test_passed, msg=msg)
 
@@ -931,8 +932,8 @@ class TestArithmetic(MultiProcessTestCase):
                     )
 
                 split = (5,)
-                reference, = tensor.split(split, dim=dim)
-                encrypted_out, = encrypted.split(split, dim=dim)
+                (reference,) = tensor.split(split, dim=dim)
+                (encrypted_out,) = encrypted.split(split, dim=dim)
                 self._check(
                     encrypted_out, reference, f"split failed with input {split}"
                 )

--- a/test/test_rss_arithmetic.py
+++ b/test/test_rss_arithmetic.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import itertools
+import logging
+from test.multiprocess_test_case import MultiProcessTestCase, get_random_test_tensor
+
+import crypten
+import torch.nn.functional as F
+from crypten.common.tensor_types import is_float_tensor
+from crypten.mpc.primitives import ArithmeticSharedTensor, resharing
+
+
+class TestRSSArithmetic(MultiProcessTestCase):
+    """
+        This class tests all functions of the ArithmeticSharedTensor.
+    """
+
+    benchmarks_enabled = False
+
+    def setUp(self):
+        super().setUp(world_size=3)
+        # We don't want the main process (rank -1) to initialize the communcator
+        if self.rank >= 0:
+            crypten.init()
+
+    def _check(self, encrypted_tensor, reference, msg, tolerance=None):
+        if tolerance is None:
+            tolerance = getattr(self, "default_tolerance", 0.05)
+        tensor = encrypted_tensor.get_plain_text()
+
+        # Check sizes match
+        self.assertTrue(tensor.size() == reference.size(), msg)
+
+        self.assertTrue(is_float_tensor(reference), "reference must be a float")
+        diff = (tensor - reference).abs_()
+        norm_diff = diff.div(tensor.abs() + reference.abs()).abs_()
+        test_passed = norm_diff.le(tolerance) + diff.le(tolerance * 0.1)
+        test_passed = test_passed.gt(0).all().item() == 1
+        if not test_passed:
+            logging.info(msg)
+            logging.info("Result = %s;\nreference = %s" % (tensor, reference))
+        self.assertTrue(test_passed, msg=msg)
+
+    def test_square(self):
+        tensor = get_random_test_tensor(is_float=True)
+        reference = tensor * tensor
+        encrypted = ArithmeticSharedTensor(tensor)
+        encrypted_out = resharing.square(encrypted)
+        encrypted_out = encrypted_out.div_(encrypted.encoder.scale)
+        self._check(encrypted_out, reference, "square failed")
+
+    def test_matmul(self):
+        """Test matrix multiplication."""
+        tensor = get_random_test_tensor(max_value=7, is_float=True)
+        for width in range(2, tensor.nelement()):
+            matrix_size = (tensor.nelement(), width)
+            matrix = get_random_test_tensor(
+                max_value=7, size=matrix_size, is_float=True
+            )
+            reference = tensor.matmul(matrix)
+            encrypted_tensor = ArithmeticSharedTensor(tensor)
+            matrix = ArithmeticSharedTensor(matrix)
+            encrypted_tensor = resharing.matmul(encrypted_tensor, matrix)
+            encrypted_tensor = encrypted_tensor.div_(matrix.encoder.scale)
+
+            self._check(
+                encrypted_tensor,
+                reference,
+                "Private-private matrix multiplication failed",
+            )
+
+    def test_conv1d_smaller_signal_one_channel(self):
+        self._conv1d(5, 1)
+
+    def test_conv1d_smaller_signal_many_channels(self):
+        self._conv1d(5, 5)
+
+    def test_conv1d_larger_signal_one_channel(self):
+        self._conv1d(16, 1)
+
+    def test_conv1d_larger_signal_many_channels(self):
+        self._conv1d(16, 5)
+
+    def _conv1d(self, signal_size, in_channels):
+        """Test convolution of encrypted tensor with public/private tensors."""
+        nbatches = [1, 3]
+        kernel_sizes = [1, 2, 3]
+        ochannels = [1, 3, 6]
+        paddings = [0, 1]
+        strides = [1, 2]
+
+        for func_name in ["conv1d", "conv_transpose1d"]:
+            for (
+                batches,
+                kernel_size,
+                out_channels,
+                padding,
+                stride,
+            ) in itertools.product(
+                nbatches, kernel_sizes, ochannels, paddings, strides
+            ):
+                input_size = (batches, in_channels, signal_size)
+                signal = get_random_test_tensor(size=input_size, is_float=True)
+
+                if func_name == "conv1d":
+                    k_size = (out_channels, in_channels, kernel_size)
+                else:
+                    k_size = (in_channels, out_channels, kernel_size)
+                kernel = get_random_test_tensor(size=k_size, is_float=True)
+
+                reference = getattr(F, func_name)(
+                    signal, kernel, padding=padding, stride=stride
+                )
+                encrypted_signal = ArithmeticSharedTensor(signal)
+                encrypted_kernel = ArithmeticSharedTensor(kernel)
+                encrypted_conv = getattr(resharing, func_name)(
+                    encrypted_signal, encrypted_kernel, padding=padding, stride=stride
+                )
+
+                encrypted_conv = encrypted_conv.div_(encrypted_signal.encoder.scale)
+
+                self._check(encrypted_conv, reference, f"{func_name} failed")
+
+    def test_conv2d_square_image_one_channel(self):
+        self._conv2d((5, 5), 1)
+
+    def test_conv2d_square_image_many_channels(self):
+        self._conv2d((5, 5), 5)
+
+    def test_conv2d_rectangular_image_one_channel(self):
+        self._conv2d((16, 7), 1)
+
+    def test_conv2d_rectangular_image_many_channels(self):
+        self._conv2d((16, 7), 5)
+
+    def _conv2d(self, image_size, in_channels):
+        """Test convolution of encrypted tensor with public/private tensors."""
+        nbatches = [1, 3]
+        kernel_sizes = [(1, 1), (2, 2), (2, 3)]
+        ochannels = [1, 3, 6]
+        paddings = [0, 1, (0, 1)]
+        strides = [1, 2, (1, 2)]
+
+        for func_name in ["conv2d", "conv_transpose2d"]:
+            for (
+                batches,
+                kernel_size,
+                out_channels,
+                padding,
+                stride,
+            ) in itertools.product(
+                nbatches, kernel_sizes, ochannels, paddings, strides
+            ):
+
+                # sample input:
+                input_size = (batches, in_channels, *image_size)
+                input = get_random_test_tensor(size=input_size, is_float=True)
+
+                # sample filtering kernel:
+                if func_name == "conv2d":
+                    k_size = (out_channels, in_channels, *kernel_size)
+                else:
+                    k_size = (in_channels, out_channels, *kernel_size)
+                kernel = get_random_test_tensor(size=k_size, is_float=True)
+
+                # perform filtering:
+                encr_matrix = ArithmeticSharedTensor(input)
+                encr_kernel = ArithmeticSharedTensor(kernel)
+                encr_conv = getattr(resharing, func_name)(
+                    encr_matrix, encr_kernel, padding=padding, stride=stride
+                )
+
+                encr_conv = encr_conv.div_(encr_matrix.encoder.scale)
+
+                # check that result is correct:
+                reference = getattr(F, func_name)(
+                    input, kernel, padding=padding, stride=stride
+                )
+                self._check(encr_conv, reference, "%s failed" % func_name)


### PR DESCRIPTION
Summary:
This diff does the following things:
1. Similar to beaver.py, create resharing.py to support replicated secret sharing in the 3PC case
2. Add test cases based on test_arithmetic.py

Future diff will integrate RSS into existing backend (or a new backend) and will add support for BinarySharedTensor as well

Differential Revision: D21742255

