### PR TITLE
Implement safe deserialization

### DIFF
--- a/crypten/common/__init__.py
+++ b/crypten/common/__init__.py
@@ -5,4 +5,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__all__ = ["rng", "tensor_types", "util"]
+__all__ = ["rng", "tensor_types", "util", "serial"]

--- a/crypten/common/serial.py
+++ b/crypten/common/serial.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import builtins
+import collections
+import io
+import pickle
+
+import torch
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    __SAFE_CLASSES = {}
+
+    @classmethod
+    def register_safe_class(cls, input_class):
+        assert isinstance(input_class, type), "Cannot register %s type as safe" % type(
+            input_class
+        )
+        classname = str(input_class).split("'")[1]
+        cls.__SAFE_CLASSES[classname] = input_class
+
+    def find_class(self, module, name):
+        if module == "builtins":
+            return getattr(builtins, name)
+        if module == "collections":
+            return getattr(collections, name)
+
+        mods = module.split(".")
+        if mods[0] == "torch":
+            result = torch
+            for mod in mods[1:]:
+                result = getattr(result, mod)
+            result = getattr(result, name)
+        else:
+            classname = f"{module}.{name}"
+            if classname not in self.__SAFE_CLASSES.keys():
+                raise ValueError(
+                    f"Deserialization is restricted for pickled module {classname}"
+                )
+
+            result = self.__SAFE_CLASSES[classname]
+
+        return result
+
+
+def register_safe_class(input_class):
+    RestrictedUnpickler.register_safe_class(input_class)
+
+
+def _assert_empty_ordered_dict(x):
+    assert isinstance(x, collections.OrderedDict)
+    assert len(x) == 0
+
+
+def _check_hooks_are_valid(result, hook_name):
+    if hasattr(result, hook_name):
+        _assert_empty_ordered_dict(getattr(result, hook_name))
+    if hasattr(result, "parameters"):
+        for param in result.parameters():
+            _assert_empty_ordered_dict(getattr(param, hook_name))
+    if hasattr(result, "modules"):
+        for module in result.modules():
+            _assert_empty_ordered_dict(getattr(module, hook_name))
+
+
+def restricted_loads(s):
+    result = RestrictedUnpickler(io.BytesIO(s)).load()
+    if torch.is_tensor(result) or isinstance(result, torch.nn.Module):
+        _check_hooks_are_valid(result, "_backward_hooks")
+    return result

--- a/crypten/communicator/distributed_communicator.py
+++ b/crypten/communicator/distributed_communicator.py
@@ -12,6 +12,7 @@ import pickle
 import numpy
 import torch
 import torch.distributed as dist
+from crypten.common import serial
 from torch.distributed import ReduceOp
 
 from .communicator import Communicator, _logging
@@ -272,7 +273,7 @@ class DistributedCommunicator(Communicator):
         data = torch.empty(size=(size,), dtype=torch.int8)
         dist.irecv(data, src=src, group=group).wait()
         buf = data.numpy().tobytes()
-        return pickle.loads(buf)
+        return serial.restricted_loads(buf)
 
     @_logging
     def broadcast_obj(self, obj, src, group=None):
@@ -295,7 +296,7 @@ class DistributedCommunicator(Communicator):
             data = torch.empty(size=(size,), dtype=torch.int8)
             dist.broadcast(data, src, group=group)
             buf = data.numpy().tobytes()
-            obj = pickle.loads(buf)
+            obj = serial.restricted_loads(buf)
         return obj
 
     def get_world_size(self):


### PR DESCRIPTION
Summary:
Python's pickle package is susceptible to RCE attacks in deserialization (using `pickle.loads()`).

This diff implements a restriced Unpickler that checks input classes for loaded objects / functions, and rejects them if they are not within a "safe set".

Also allows users to register new safe types that can be sent as objects.

Also updated objects send / recv / broadcast tests to communicate several types of safe standard / custom objects, and tests that invalid objects are rejected.

This is a 2nd attempt at D21574976, which I plan to abandon since it does not allow torch tensors to be communicated.

Differential Revision: D21745034

