### PR TITLE
Use floordiv in encoder (#209)

### DIFF
--- a/crypten/encoder.py
+++ b/crypten/encoder.py
@@ -21,7 +21,7 @@ def nearest_integer_division(tensor, integer):
     pos_remainder = (1 - lez) * tensor % integer
     neg_remainder = lez * ((integer - tensor) % integer)
     remainder = pos_remainder + neg_remainder
-    quotient = tensor / integer
+    quotient = tensor // integer
     correction = (2 * remainder > integer).long()
     return quotient + tensor.sign() * correction
 
@@ -64,7 +64,7 @@ class FixedPointEncoder:
         assert is_int_tensor(tensor), "input must be a LongTensor"
         if self._scale > 1:
             correction = (tensor < 0).long()
-            dividend = tensor / self._scale - correction
+            dividend = tensor // self._scale - correction
             remainder = tensor % self._scale
             remainder += (remainder == 0).long() * self._scale * correction
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/fairinternal/CrypTen/pull/209

PyTorch is making the final switch to a truediv that will correspond to floating point division for LongTensors.

This diff fixes instances in encoder.py that still used truediv where we need floordiv

Differential Revision: D21839219

