### PR TITLE
Rename mpc function to(ptype) to to_ptype(ptype)

### DIFF
--- a/crypten/mpc/mpc.py
+++ b/crypten/mpc/mpc.py
@@ -39,7 +39,7 @@ def mode(ptype, inplace=False):
             # @wraps ensures docstrings are updated
             @wraps(func)
             def convert_wrapper(self, *args, **kwargs):
-                result = self.to(ptype)
+                result = self.to_ptype(ptype)
                 return func(result, *args, **kwargs)
 
             return convert_wrapper
@@ -170,7 +170,7 @@ class MPCTensor(CrypTensor):
         self.ptype = other.ptype
 
     # Handle share types and conversions
-    def to(self, ptype, **kwargs):
+    def to_ptype(self, ptype, **kwargs):
         """Converts self._tensor to the given ptype
 
         Args:
@@ -185,11 +185,11 @@ class MPCTensor(CrypTensor):
 
     def arithmetic(self):
         """Converts self._tensor to arithmetic secret sharing"""
-        return self.to(Ptype.arithmetic)
+        return self.to_ptype(Ptype.arithmetic)
 
     def binary(self):
         """Converts self._tensor to binary secret sharing"""
-        return self.to(Ptype.binary)
+        return self.to_ptype(Ptype.binary)
 
     def get_plain_text(self, dst=None):
         """Decrypts the tensor."""
@@ -266,7 +266,7 @@ class MPCTensor(CrypTensor):
         # Make all inputs MPCTensors of given ptype
         for i, tensor in enumerate(tensors):
             if tensor.ptype != _ptype:
-                tensors[i] = tensor.to(_ptype)
+                tensors[i] = tensor.to_ptype(_ptype)
 
         # Operate on all input tensors
         result = tensors[0].clone()
@@ -398,7 +398,7 @@ class MPCTensor(CrypTensor):
     def _ltz(self, _scale=True):
         """Returns 1 for elements that are < 0 and 0 otherwise"""
         shift = torch.iinfo(torch.long).bits - 1
-        result = (self >> shift).to(Ptype.arithmetic, bits=1)
+        result = (self >> shift).to_ptype(Ptype.arithmetic, bits=1)
         if _scale:
             return result * result.encoder._scale
         else:
@@ -444,7 +444,7 @@ class MPCTensor(CrypTensor):
         x0._tensor = x0._tensor.eq(x1._tensor)
 
         # Convert to Arithmetic sharing
-        result = x0.to(Ptype.arithmetic, bits=1)
+        result = x0.to_ptype(Ptype.arithmetic, bits=1)
 
         # Handle scaling
         if _scale:

--- a/test/test_arithmetic.py
+++ b/test/test_arithmetic.py
@@ -206,7 +206,7 @@ class TestArithmetic(MultiProcessTestCase):
                 self._check(encrypted_tensor, reference, "division failed")
 
                 divisor = get_random_test_tensor(is_float=float)
-                divisor += (divisor == 0).to(dtype=divisor.dtype)  # div by 0
+                divisor += (divisor == 0).to_ptype(dtype=divisor.dtype)  # div by 0
 
                 reference = tensor.div(divisor)
                 encrypted_tensor = ArithmeticSharedTensor(tensor)

--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -1452,7 +1452,7 @@ class TestMPC(object):
             encrypted_tensor = MPCTensor(tensor)
             self.assertEqual(encrypted_tensor.ptype, Ptype.arithmetic)
 
-            binary_encrypted_tensor = encrypted_tensor.to(Ptype.binary)
+            binary_encrypted_tensor = encrypted_tensor.to_ptype(Ptype.binary)
             self.assertEqual(binary_encrypted_tensor.ptype, Ptype.binary)
 
             # check original encrypted_tensor was not modified after conversion
@@ -1463,7 +1463,7 @@ class TestMPC(object):
                 "BinarySharedTensor.",
             )
 
-            encrypted_from_binary = binary_encrypted_tensor.to(Ptype.arithmetic)
+            encrypted_from_binary = binary_encrypted_tensor.to_ptype(Ptype.arithmetic)
             self._check(
                 encrypted_from_binary,
                 tensor,


### PR DESCRIPTION
Summary: Rename .to(ptype) to .to_ptype(ptype) to address comment in D21952814

Differential Revision: D21954885

