### PR TITLE
Implement CUDALongTensor as wrapper for cuda_patches

### DIFF
--- a/crypten/cuda/__init__.py
+++ b/crypten/cuda/__init__.py
@@ -1,0 +1,4 @@
+from .cuda_tensor import CUDALongTensor
+
+
+__all__ = ["CUDALongTensor"]

--- a/crypten/cuda/cuda_tensor.py
+++ b/crypten/cuda/cuda_tensor.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+
+import torch
+import torch.nn as nn
+
+
+torch_stack = torch.stack
+torch_cat = torch.cat
+
+
+def implements(torch_function):
+    """Register a torch function override for CUDALongTensor"""
+
+    @functools.wraps(torch_function)
+    def decorator(func):
+        HANDLED_FUNCTIONS[torch_function] = func
+        return func
+
+    return decorator
+
+
+HANDLED_FUNCTIONS = {}
+
+
+class CUDALongTensor(object):
+    def __init__(self, data=None, *args, **kwargs):
+        self._tensor = None
+        if data is None:
+            return
+        if isinstance(data, CUDALongTensor):
+            self._tensor = data._tensor
+        elif torch.is_tensor(data):
+            self._tensor = data
+        else:
+            self._tensor = torch.as_tensor(data, device="cuda", *args, **kwargs)
+
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        if func not in HANDLED_FUNCTIONS or not all(
+            issubclass(t, (torch.Tensor, CUDALongTensor)) for t in types
+        ):
+            args = [t.tensor() if hasattr(t, "tensor") else t for t in args]
+            result = func(*args, **kwargs)
+            if torch.is_tensor(result):
+                return CUDALongTensor(result)
+            return result
+        return HANDLED_FUNCTIONS[func](*args, **kwargs)
+
+    def __repr__(self):
+        return "CUDALongTensor({})".format(self._tensor)
+
+    def __setitem__(self, index, value):
+        self._tensor[index] = value.data
+
+    @property
+    def device(self):
+        return self._tensor.device
+
+    @property
+    def is_cuda(self):
+        return True
+
+    @property
+    def shape(self):
+        return self._tensor.shape
+
+    @property
+    def data(self):
+        return self._tensor.data
+
+    @property
+    def dtype(self):
+        return self._tensor.dtype
+
+    def tensor(self):
+        return self._tensor
+
+    def to(self, device):
+        if device is "cpu":
+            return self.cpu()
+        return self._tensor
+
+    def cpu(self):
+        return self._tensor.cpu()
+
+    def shallow_copy(self):
+        """Create a shallow copy of the input tensor."""
+        # TODO: Rename this to __copy__()?
+        result = CUDALongTensor(self._tensor)
+        return result
+
+    def clone(self):
+        """Create a deep copy of the input tensor."""
+        # TODO: Rename this to __deepcopy__()?
+        result = CUDALongTensor()
+        result._tensor = self._tensor.clone()
+        return result
+
+    @staticmethod
+    def __encode_as_fp64(x):
+        """Converts a CUDALongTensor `x` to an encoding of
+        torch.cuda.DoubleTensor that represent the same data.
+        """
+
+        x_block = CUDALongTensor.stack(
+            [(x >> (16 * i)) & (2 ** 16 - 1) for i in range(4)]
+        )
+
+        return x_block.double()
+
+    @staticmethod
+    def __decode_as_int64(x_enc):
+        """Converts a CUDALongTensor `x` encoded as torch.cuda.DoubleTensor
+        back to the CUDALongTensor it encodes
+        """
+        x_enc = x_enc.long()
+
+        x = (x_enc[3] + x_enc[6] + x_enc[9] + x_enc[12]) << 48
+        x += (x_enc[2] + x_enc[5] + x_enc[8]) << 32
+        x += (x_enc[1] + x_enc[4]) << 16
+        x += x_enc[0]
+
+        return CUDALongTensor(x)
+
+    @staticmethod
+    def __patched_conv_ops(op, x, y, *args, **kwargs):
+        x_encoded = CUDALongTensor.__encode_as_fp64(x).data
+        y_encoded = CUDALongTensor.__encode_as_fp64(y).data
+
+        repeat_idx = [1] * (x_encoded.dim() - 1)
+        x_enc_span = x_encoded.repeat(4, *repeat_idx)
+        y_enc_span = torch.repeat_interleave(y_encoded, repeats=4, dim=0)
+
+        bs, c, *img = x.size()
+        c_out, c_in, *ks = y.size()
+
+        x_enc_span = x_enc_span.transpose_(0, 1).reshape(bs, 16 * c, *img)
+        y_enc_span = y_enc_span.reshape(16 * c_out, c_in, *ks)
+
+        c_z = c_out if op in ["conv1d", "conv2d"] else c_in
+
+        z_encoded = getattr(torch, op)(
+            x_enc_span, y_enc_span, *args, **kwargs, groups=16
+        )
+        z_encoded = z_encoded.reshape(bs, 16, c_z, *z_encoded.size()[2:]).transpose_(
+            0, 1
+        )
+
+        return CUDALongTensor.__decode_as_int64(z_encoded)
+
+    @staticmethod
+    def stack(tensors, *args, **kwargs):
+        tensors = [t.tensor() if hasattr(t, "tensor") else t for t in tensors]
+        return CUDALongTensor(torch_stack(tensors, *args, **kwargs))
+
+    @staticmethod
+    def cat(tensors, *args, **kwargs):
+        tensors = [t.tensor() if hasattr(t, "tensor") else t for t in tensors]
+        return CUDALongTensor(torch_cat(tensors, *args, **kwargs))
+
+    @implements(torch.matmul)
+    def matmul(x, y, *args, **kwargs):
+
+        x_encoded = CUDALongTensor.__encode_as_fp64(x)
+        y_encoded = CUDALongTensor.__encode_as_fp64(y)
+
+        # span x and y for cross multiplication
+        repeat_idx = [1] * (x_encoded.dim() - 1)
+        x_enc_span = x_encoded.repeat(4, *repeat_idx)
+        y_enc_span = torch.repeat_interleave(y_encoded, repeats=4, dim=0)
+
+        z_encoded = torch.matmul(x_enc_span.data, y_enc_span.data, *args, **kwargs)
+
+        return CUDALongTensor.__decode_as_int64(z_encoded)
+
+    @implements(torch.conv1d)
+    def conv1d(input, weight, *args, **kwargs):
+        return CUDALongTensor.__patched_conv_ops(
+            "conv1d", input, weight, *args, **kwargs
+        )
+
+    @implements(torch.conv_transpose1d)
+    def conv_transpose1d(input, weight, *args, **kwargs):
+        return CUDALongTensor.__patched_conv_ops(
+            "conv_transpose1d", input, weight, *args, **kwargs
+        )
+
+    @implements(torch.conv2d)
+    def conv2d(input, weight, *args, **kwargs):
+        return CUDALongTensor.__patched_conv_ops(
+            "conv2d", input, weight, *args, **kwargs
+        )
+
+    @implements(torch.conv_transpose2d)
+    def conv_transpose2d(input, weight, *args, **kwargs):
+        return CUDALongTensor.__patched_conv_ops(
+            "conv_transpose2d", input, weight, *args, **kwargs
+        )
+
+    @implements(torch.broadcast_tensors)
+    def broadcast_tensors(*tensors):
+        tensor_list = [t.data for t in tensors]
+        results = torch.broadcast_tensors(*tensor_list)
+        results = [CUDALongTensor(t) for t in results]
+        return results
+
+    def split(self, y, *args, **kwargs):
+        splits = self._tensor.split(y, *args, **kwargs)
+        splits = [CUDALongTensor(split) for split in splits]
+        return splits
+
+    def unbind(self, dim=0):
+        results = torch.unbind(self._tensor, dim)
+        results = tuple([CUDALongTensor(t) for t in results])
+        return results
+
+    def __iadd__(self, y):
+        if isinstance(y, CUDALongTensor):
+            y = y._tensor
+        self._tensor += y
+        return self
+
+    def __isub__(self, y):
+        if isinstance(y, CUDALongTensor):
+            y = y.tensor()
+        self._tensor -= y
+        return self
+
+    def __imul__(self, y):
+        if isinstance(y, CUDALongTensor):
+            y = y.tensor()
+        self._tensor *= y
+        return self
+
+    def __ifloordiv__(self, y):
+        if isinstance(y, CUDALongTensor):
+            y = y.tensor()
+        self._tensor //= y
+        return self
+
+    def __idiv__(self, y):
+        if isinstance(y, CUDALongTensor):
+            y = y.tensor()
+        self._tensor /= y
+        return self
+
+    def __imod__(self, y):
+        if isinstance(y, CUDALongTensor):
+            y = y.tensor()
+        self._tensor %= y
+        return self
+
+    def __iand__(self, y):
+        if isinstance(y, CUDALongTensor):
+            y = y.tensor()
+        self._tensor &= y
+        return self
+
+    def __ixor__(self, y):
+        if isinstance(y, CUDALongTensor):
+            y = y.tensor()
+        self._tensor ^= y
+        return self
+
+    def __ipow__(self, y):
+        if isinstance(y, CUDALongTensor):
+            y = y.tensor()
+        self._tensor **= y
+        return self
+
+    def __and__(self, y):
+        result = self.clone()
+        return result.__iand__(y)
+
+    def __xor__(self, y):
+        result = self.clone()
+        return result.__ixor__(y)
+
+    def __add__(self, y):
+        result = self.clone()
+        return result.__iadd__(y)
+
+    def __sub__(self, y):
+        result = self.clone()
+        return result.__isub__(y)
+
+    def __rsub__(self, y):
+        result = self.clone()
+        result._tensor = y - result._tensor
+        return result
+
+    def __mul__(self, y):
+        result = self.clone()
+        return result.__imul__(y)
+
+    def __floordiv__(self, y):
+        result = self.clone()
+        return result.__ifloordiv__(y)
+
+    def __truediv__(self, y):
+        result = self.clone()
+        return result.__idiv__(y)
+
+    def __mod__(self, y):
+        result = self.clone()
+        return result.__imod__(y)
+
+    def __pow__(self, y):
+        result = self.clone()
+        return result.__ipow__(y)
+
+    def __neg__(self):
+        result = self.clone()
+        result._tensor = -result._tensor
+        return result
+
+    def __eq__(self, y):
+        return CUDALongTensor(self._tensor == y)
+
+    def __ne__(self, y):
+        return CUDALongTensor(self._tensor != y)
+
+    def __lt__(self, y):
+        return CUDALongTensor(self._tensor < y)
+
+    def __gt__(self, y):
+        return CUDALongTensor(self._tensor > y)
+
+    def __le__(self, y):
+        return CUDALongTensor(self._tensor <= y)
+
+    def __ge__(self, y):
+        return CUDALongTensor(self._tensor >= y)
+
+    def lshift_(self, value):
+        """Right shift elements by `value` bits"""
+        assert isinstance(value, int), "lshift must take an integer argument."
+        self._tensor <<= value
+        return self
+
+    def lshift(self, value):
+        """Left shift elements by `value` bits"""
+        return self.clone().lshift_(value)
+
+    def rshift_(self, value):
+        """Right shift elements by `value` bits"""
+        assert isinstance(value, int), "rshift must take an integer argument."
+        self._tensor >>= value
+        return self
+
+    def rshift(self, value):
+        """Right shift elements by `value` bits"""
+        return self.clone().rshift_(value)
+
+    __lshift__ = lshift
+    __rshift__ = rshift
+
+    # In-place bitwise operators
+    __ilshift__ = lshift_
+    __irshift__ = rshift_
+
+    __radd__ = __add__
+    __rmul__ = __mul__
+    __rpow__ = __pow__
+
+
+REGULAR_FUNCTIONS = [
+    "__getitem__",
+    "index_select",
+    "view",
+    "flatten",
+    "t",
+    "transpose",
+    "unsqueeze",
+    "repeat",
+    "squeeze",
+    "narrow",
+    "expand",
+    "roll",
+    "unfold",
+    "flip",
+    "trace",
+    "prod",
+    "sum",
+    "cumsum",
+    "reshape",
+    "permute",
+    "pow",
+    "float",
+    "long",
+    "double",
+    "scatter",
+    "scatter_add",
+    "index_fill",
+    "index_add",
+    "take",
+    "gather",
+    "where",
+    "add",
+    "sub",
+    "mul",
+    "div",
+]
+
+PROPERTY_FUNCTIONS = [
+    "__len__",
+    "nelement",
+    "dim",
+    "size",
+    "numel",
+    "all",
+    "item",
+    "le",
+    "ge",
+    "gt",
+    "lt",
+    "eq",
+    "ne",
+    "neg",
+    "abs",
+    "sign",
+    "nonzero",
+]
+
+INPLACE_FUNCTIONS = [
+    "add_",
+    "sub_",
+    "mul_",
+    "div_",
+    "copy_",
+    "set_",
+    "abs_",
+    "neg_",
+    "index_fill_",
+    "index_add_",
+    "scatter_",
+    "scatter_add_",
+]
+
+ARITHMETIC_FUNCTIONS = [
+    "add",
+    "add_",
+    "sub",
+    "sub_",
+    "mul",
+    "mul_",
+    "div",
+    "div_",
+    "copy_",
+    "set_",
+]
+
+
+def _add_regular_function(func_name):
+    """
+    Adds function to `CUDALongTensor` that is applied directly on the underlying
+    `_tensor` attribute, and stores the result in the same attribute.
+    """
+
+    def regular_func(self, *args, **kwargs):
+        result = self.shallow_copy()
+        args = [t.tensor() if hasattr(t, "tensor") else t for t in args]
+        for key, value in kwargs.items():
+            if hasattr(value, "tensor"):
+                kwargs[key] = value.tensor()
+        result._tensor = getattr(result._tensor, func_name)(*args, **kwargs)
+        return result
+
+    setattr(CUDALongTensor, func_name, regular_func)
+
+
+def _add_property_function(func_name):
+    """
+    Adds function to `CUDALongTensor` that is applied directly on the underlying
+    `_tensor` attribute, and returns the result of that function.
+    """
+
+    def property_func(self, *args, **kwargs):
+        result = getattr(self._tensor, func_name)(*args, **kwargs)
+        return result
+
+    setattr(CUDALongTensor, func_name, property_func)
+
+
+def _add_inplace_function(func_name):
+    def inplace_func(self, *args, **kwargs):
+        args = [t.tensor() if hasattr(t, "tensor") else t for t in args]
+        for key, value in kwargs.items():
+            if hasattr(value, "tensor"):
+                kwargs[key] = value.tensor()
+
+        result = getattr(self._tensor, func_name)(*args, **kwargs)
+        self._tensor.set_(result)
+        return self
+
+    setattr(CUDALongTensor, func_name, inplace_func)
+
+
+for func_name in REGULAR_FUNCTIONS:
+    _add_regular_function(func_name)
+
+for func_name in PROPERTY_FUNCTIONS:
+    _add_property_function(func_name)
+
+for func_name in INPLACE_FUNCTIONS:
+    _add_inplace_function(func_name)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import itertools
+import logging
+import math
+import unittest
+from test.multiprocess_test_case import MultiProcessTestCase, get_random_test_tensor
+
+import crypten
+import crypten.communicator as comm
+import torch
+import torch.nn.functional as F
+from crypten.common.rng import generate_kbit_random_tensor, generate_random_ring_element
+from crypten.common.tensor_types import is_float_tensor, is_int_tensor
+from crypten.cuda import CUDALongTensor
+from crypten.mpc import ConfigManager, MPCTensor, ptype as Ptype
+from crypten.mpc.primitives import ArithmeticSharedTensor, BinarySharedTensor, beaver
+
+
+class TestCUDA(object):
+    """
+        This class tests all functions of CUDALongTensor as well as its integration with MPCTensor.
+    """
+
+    def _check(self, encrypted_tensor, reference, msg, dst=None, tolerance=None):
+        if tolerance is None:
+            tolerance = getattr(self, "default_tolerance", 0.05)
+        tensor = encrypted_tensor.get_plain_text(dst=dst)
+        if dst is not None and dst != self.rank:
+            self.assertIsNone(tensor)
+            return
+
+        # Check sizes match
+        self.assertTrue(tensor.size() == reference.size(), msg)
+
+        self.assertTrue(is_float_tensor(reference), "reference must be a float")
+
+        if tensor.device != reference.device:
+            tensor = tensor.cpu()
+            reference = reference.cpu()
+
+        diff = (tensor - reference).abs_()
+        norm_diff = diff.div(tensor.abs() + reference.abs()).abs_()
+        test_passed = norm_diff.le(tolerance) + diff.le(tolerance * 0.1)
+        test_passed = test_passed.gt(0).all().item() == 1
+        if not test_passed:
+            logging.info(msg)
+            logging.info("Result %s" % tensor)
+            logging.info("Reference %s" % reference)
+            logging.info("Result - Reference = %s" % (tensor - reference))
+        self.assertTrue(test_passed, msg=msg)
+
+    def _check_tuple(self, encrypted_tuple, reference, msg, tolerance=None):
+        self.assertTrue(isinstance(encrypted_tuple, tuple))
+        self.assertEqual(len(encrypted_tuple), len(reference))
+        for i in range(len(reference)):
+            self._check(encrypted_tuple[i], reference[i], msg, tolerance=tolerance)
+
+    def _check_int(self, result, reference, msg):
+        # Check sizes match
+        self.assertTrue(result.size() == reference.size(), msg)
+        self.assertTrue(is_int_tensor(result), "result must be a int tensor")
+        self.assertTrue(is_int_tensor(reference), "reference must be a int tensor")
+
+        is_eq = (result == reference).all().item() == 1
+
+        if not is_eq:
+            logging.info(msg)
+            logging.info("Result %s" % result)
+            logging.info("Reference %s" % reference)
+            logging.info("Result - Reference = %s" % (result - reference))
+
+        self.assertTrue(is_eq, msg=msg)
+
+    @unittest.skipIf(torch.cuda.is_available() is False, "requires CUDA")
+    def test_patched_matmul(self):
+        x = get_random_test_tensor(max_value=2 ** 62, is_float=False)
+        x_cuda = CUDALongTensor(x.cuda())
+        for width in range(2, x.nelement()):
+            matrix_size = (x.nelement(), width)
+            y = get_random_test_tensor(
+                size=matrix_size, max_value=2 ** 62, is_float=False
+            )
+
+            y_cuda = CUDALongTensor(y.cuda())
+            z = torch.matmul(x_cuda, y_cuda).data
+
+            reference = torch.matmul(x, y)
+            self._check_int(z.cpu(), reference, "matmul failed for cuda_patches")
+
+    @unittest.skipIf(torch.cuda.is_available() is False, "requires CUDA")
+    def test_conv1d_smaller_signal_one_channel(self):
+        self._patched_conv1d(5, 1)
+
+    @unittest.skipIf(torch.cuda.is_available() is False, "requires CUDA")
+    def test_conv1d_smaller_signal_many_channels(self):
+        self._patched_conv1d(5, 5)
+
+    @unittest.skipIf(torch.cuda.is_available() is False, "requires CUDA")
+    def test_conv1d_larger_signal_one_channel(self):
+        self._patched_conv1d(16, 1)
+
+    @unittest.skipIf(torch.cuda.is_available() is False, "requires CUDA")
+    def test_conv1d_larger_signal_many_channels(self):
+        self._patched_conv1d(16, 5)
+
+    def _conv1d(self, signal_size, in_channels):
+        """Test convolution of encrypted tensor with public/private tensors."""
+        nbatches = [1, 3]
+        kernel_sizes = [1, 2, 3]
+        ochannels = [1, 3, 6]
+        paddings = [0, 1]
+        strides = [1, 2]
+
+        for func_name in ["conv1d", "conv_transpose1d"]:
+            for kernel_type in [lambda x: x, MPCTensor]:
+                for (
+                    batches,
+                    kernel_size,
+                    out_channels,
+                    padding,
+                    stride,
+                ) in itertools.product(
+                    nbatches, kernel_sizes, ochannels, paddings, strides
+                ):
+                    input_size = (batches, in_channels, signal_size)
+                    signal = get_random_test_tensor(
+                        size=input_size, is_float=True
+                    ).cuda()
+
+                    if func_name == "conv1d":
+                        k_size = (out_channels, in_channels, kernel_size)
+                    else:
+                        k_size = (in_channels, out_channels, kernel_size)
+                    kernel = get_random_test_tensor(size=k_size, is_float=True).cuda()
+
+                    reference = getattr(F, func_name)(
+                        signal, kernel, padding=padding, stride=stride
+                    )
+                    encrypted_signal = MPCTensor(signal)
+                    encrypted_kernel = kernel_type(kernel)
+                    encrypted_conv = getattr(encrypted_signal, func_name)(
+                        encrypted_kernel, padding=padding, stride=stride
+                    )
+
+                    self._check(encrypted_conv, reference, f"{func_name} failed")
+
+    def _patched_conv1d(self, signal_size, in_channels):
+        """Test convolution of torch.cuda.LongTensor with cuda_patches technique."""
+        nbatches = [1, 3]
+        kernel_sizes = [1, 2, 3]
+        ochannels = [1, 3, 6]
+        paddings = [0, 1]
+        strides = [1, 2]
+
+        for func_name in ["conv1d", "conv_transpose1d"]:
+            for (
+                batches,
+                kernel_size,
+                out_channels,
+                padding,
+                stride,
+            ) in itertools.product(
+                nbatches, kernel_sizes, ochannels, paddings, strides
+            ):
+                input_size = (batches, in_channels, signal_size)
+                signal = get_random_test_tensor(size=input_size, is_float=False)
+
+                if func_name == "conv1d":
+                    k_size = (out_channels, in_channels, kernel_size)
+                else:
+                    k_size = (in_channels, out_channels, kernel_size)
+                kernel = get_random_test_tensor(size=k_size, is_float=False)
+
+                signal_cuda = CUDALongTensor(signal.cuda())
+                kernel_cuda = CUDALongTensor(kernel.cuda())
+
+                reference = getattr(F, func_name)(
+                    signal, kernel, padding=padding, stride=stride
+                )
+                result = getattr(F, func_name)(
+                    signal_cuda, kernel_cuda, padding=padding, stride=stride
+                )
+                result = result.data.cpu()
+
+                self._check_int(result, reference, f"{func_name} failed")
+
+    @unittest.skipIf(torch.cuda.is_available() is False, "requires CUDA")
+    def test_conv2d_square_image_one_channel(self):
+        self._patched_conv2d((5, 5), 1)
+
+    @unittest.skipIf(torch.cuda.is_available() is False, "requires CUDA")
+    def test_conv2d_square_image_many_channels(self):
+        self._patched_conv2d((5, 5), 5)
+
+    @unittest.skipIf(torch.cuda.is_available() is False, "requires CUDA")
+    def test_conv2d_rectangular_image_one_channel(self):
+        self._patched_conv2d((16, 7), 1)
+
+    @unittest.skipIf(torch.cuda.is_available() is False, "requires CUDA")
+    def test_conv2d_rectangular_image_many_channels(self):
+        self._patched_conv2d((16, 7), 5)
+
+    def _patched_conv2d(self, image_size, in_channels):
+        """Test convolution of torch.cuda.LongTensor with cuda_patches technique."""
+        nbatches = [1, 3]
+        kernel_sizes = [(1, 1), (2, 2), (2, 3)]
+        ochannels = [1, 3, 6]
+        paddings = [0, 1, (0, 1)]
+        strides = [1, 2, (1, 2)]
+
+        for func_name in ["conv2d"]:
+            for (
+                batches,
+                kernel_size,
+                out_channels,
+                padding,
+                stride,
+            ) in itertools.product(
+                nbatches, kernel_sizes, ochannels, paddings, strides
+            ):
+
+                # sample input:
+                input_size = (batches, in_channels, *image_size)
+                input = get_random_test_tensor(size=input_size, is_float=False)
+
+                # sample filtering kernel:
+                if func_name == "conv2d":
+                    k_size = (out_channels, in_channels, *kernel_size)
+                else:
+                    k_size = (in_channels, out_channels, *kernel_size)
+                kernel = get_random_test_tensor(size=k_size, is_float=False)
+
+                input_cuda = CUDALongTensor(input.cuda())
+                kernel_cuda = CUDALongTensor(kernel.cuda())
+
+                result = getattr(F, func_name)(
+                    input_cuda, kernel_cuda, padding=padding, stride=stride
+                )
+                result = result.data.cpu()
+
+                # check that result is correct:
+                reference = getattr(F, func_name)(
+                    input, kernel, padding=padding, stride=stride
+                )
+                self._check_int(result, reference, "%s failed" % func_name)


### PR DESCRIPTION
Summary:
This diff implements CUDALongTensor, a wrapper for cuda_patches in D21882865

When user select GPU for backend, CUDALongTensor will be selected. Internally, it will convert a LongTensor into FloatTensor to utilize existing CUDA kernels for floating points, and then convert it back to LongTensor.

Future diffs will integrate CUDALongTensor into CrypTen

Differential Revision: D22071446

