### PR TITLE
Support model.to(device) for CrypTen's private model

### DIFF
--- a/crypten/common/util.py
+++ b/crypten/common/util.py
@@ -38,7 +38,7 @@ def count_wraps(share_list):
     We compute this by counting the number of overflows and underflows as we
     traverse the list of shares.
     """
-    result = torch.zeros(size=share_list[0].size(), dtype=torch.long)
+    result = torch.zeros_like(share_list[0], dtype=torch.long)
     prev = share_list[0]
     for cur in share_list[1:]:
         next = cur + prev

--- a/crypten/cryptensor.py
+++ b/crypten/cryptensor.py
@@ -174,7 +174,7 @@ class CrypTensor(object, metaclass=CrypTensorMetaclass):
                 # TODO: Remove the default grad_input value currently set to all_ones
                 # if undefined, set gradient input to all ones:
                 if grad_input is None:
-                    grad_input = self.new(torch.ones(self.size()))
+                    grad_input = self.new(torch.ones_like(self.share))
 
                 # check that we can actually backpropagate:
                 if self.grad_fn is None:

--- a/crypten/nn/module.py
+++ b/crypten/nn/module.py
@@ -138,6 +138,14 @@ class Module:
                 pre = module_name if prefix is None else prefix + "." + module_name
                 yield from module.named_parameters(recurse=recurse, prefix=pre)
 
+    def to(self, *args, **kwargs):
+        """Moves and/or casts the parameters and buffers."""
+        for name, param in self._parameters.items():
+            self.set_parameter(name, param.to(*args, **kwargs))
+        for module_name, module in self.named_modules():
+            module.to(*args, **kwargs)
+        return self
+
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         """
         Saves module state to `destination` dictionary, containing a state


### PR DESCRIPTION
Summary: User can call private_model.to(device) to move the private_model to the specified device.

Differential Revision: D22245866

