### PR TITLE
Support CUDALongTensor for TTP

### DIFF
--- a/crypten/common/util.py
+++ b/crypten/common/util.py
@@ -84,7 +84,7 @@ def pool_reshape(input, kernel_size, padding=None, stride=None, pad_value=0):
     out_size = (n, c, h, w)
 
     # Reshape input to arrange kernels to be represented by rows
-    kernel_indices = torch.tensor(range(k[1]))
+    kernel_indices = torch.tensor(range(k[1]), device=input.device)
     kernel_indices = torch.cat(
         [kernel_indices + i * input.size(3) for i in range(k[0])]
     )

--- a/crypten/mpc/provider/ttp_provider.py
+++ b/crypten/mpc/provider/ttp_provider.py
@@ -41,9 +41,9 @@ class TrustedThirdParty:
             c_size = getattr(torch, op)(a, b, *args, **kwargs).size()
             c = generate_random_ring_element(c_size, generator=generator)
 
-        a = ArithmeticSharedTensor.from_shares(a, precision=0)
-        b = ArithmeticSharedTensor.from_shares(b, precision=0)
-        c = ArithmeticSharedTensor.from_shares(c, precision=0)
+        a = ArithmeticSharedTensor.from_shares(a.to(device), precision=0)
+        b = ArithmeticSharedTensor.from_shares(b.to(device), precision=0)
+        c = ArithmeticSharedTensor.from_shares(c.to(device), precision=0)
         return a, b, c
 
     @staticmethod
@@ -58,8 +58,8 @@ class TrustedThirdParty:
         else:
             r2 = generate_random_ring_element(size, generator=generator)
 
-        r = ArithmeticSharedTensor.from_shares(r, precision=0)
-        r2 = ArithmeticSharedTensor.from_shares(r2, precision=0)
+        r = ArithmeticSharedTensor.from_shares(r.to(device), precision=0)
+        r2 = ArithmeticSharedTensor.from_shares(r2.to(device), precision=0)
         return r, r2
 
     @staticmethod
@@ -78,9 +78,9 @@ class TrustedThirdParty:
             c = generate_kbit_random_tensor(size2, generator=generator)
 
         # Stack to vectorize scatter function
-        a = BinarySharedTensor.from_shares(a)
-        b = BinarySharedTensor.from_shares(b)
-        c = BinarySharedTensor.from_shares(c)
+        a = BinarySharedTensor.from_shares(a.to(device))
+        b = BinarySharedTensor.from_shares(b.to(device))
+        c = BinarySharedTensor.from_shares(c.to(device))
         return a, b, c
 
     @staticmethod
@@ -95,8 +95,8 @@ class TrustedThirdParty:
         else:
             theta_r = generate_random_ring_element(size, generator=generator)
 
-        r = ArithmeticSharedTensor.from_shares(r, precision=0)
-        theta_r = ArithmeticSharedTensor.from_shares(theta_r, precision=0)
+        r = ArithmeticSharedTensor.from_shares(r.to(device), precision=0)
+        theta_r = ArithmeticSharedTensor.from_shares(theta_r.to(device), precision=0)
         return r, theta_r
 
     @staticmethod
@@ -113,8 +113,8 @@ class TrustedThirdParty:
         else:
             rA = generate_random_ring_element(size, generator=generator)
 
-        rA = ArithmeticSharedTensor.from_shares(rA, precision=0)
-        rB = BinarySharedTensor.from_shares(rB)
+        rA = ArithmeticSharedTensor.from_shares(rA.to(device), precision=0)
+        rB = BinarySharedTensor.from_shares(rB.to(device))
         return rA, rB
 
     @staticmethod
@@ -133,7 +133,7 @@ class TrustedThirdParty:
             samples = TTPClient.get().ttp_request("rand", *sizes, encoder=encoder)
         else:
             samples = generate_random_ring_element(sizes, generator=generator)
-        return ArithmeticSharedTensor.from_shares(samples)
+        return ArithmeticSharedTensor.from_shares(samples.to(device))
 
     @staticmethod
     def _init():

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -513,7 +513,6 @@ class TestTFP(MultiProcessTestCase, TestCUDA):
         super(TestTFP, self).tearDown()
 
 
-@unittest.skip("TTP is currently not supported for CUDA")
 class TestTTP(MultiProcessTestCase, TestCUDA):
     def __init__(self, methodName):
         super().__init__(methodName)


### PR DESCRIPTION
Summary:
CUDA integration for TTP (trusted third party)

All randomness will be generated in CPU and then move to the specified device. I choose this design because `torch.distributed.isend` and `torch.distributed.irecv` is not available in CUDA. In addition, `torch.Generator` with the same seed produce different result on CPU and GPU.

Differential Revision: D22262412

