### PR TITLE
Optimize floating point conversion for CUDALongTensor

### DIFF
--- a/crypten/cuda/cuda_tensor.py
+++ b/crypten/cuda/cuda_tensor.py
@@ -140,9 +140,8 @@ class CUDALongTensor(object):
         """Converts a CUDALongTensor `x` to an encoding of
         torch.cuda.DoubleTensor that represent the same data.
         """
-
         x_block = CUDALongTensor.stack(
-            [(x >> (16 * i)) & (2 ** 16 - 1) for i in range(4)]
+            [(x >> (22 * i)) & (2 ** 22 - 1) for i in range(3)]
         )
 
         return x_block.double()
@@ -154,9 +153,8 @@ class CUDALongTensor(object):
         """
         x_enc = x_enc.long()
 
-        x = (x_enc[3] + x_enc[6] + x_enc[9] + x_enc[12]) << 48
-        x += (x_enc[2] + x_enc[5] + x_enc[8]) << 32
-        x += (x_enc[1] + x_enc[4]) << 16
+        x = (x_enc[2] + x_enc[4] + x_enc[6]) << 44
+        x += (x_enc[1] + x_enc[3]) << 22
         x += x_enc[0]
 
         return CUDALongTensor(x)
@@ -167,21 +165,21 @@ class CUDALongTensor(object):
         y_encoded = CUDALongTensor.__encode_as_fp64(y).data
 
         repeat_idx = [1] * (x_encoded.dim() - 1)
-        x_enc_span = x_encoded.repeat(4, *repeat_idx)
-        y_enc_span = torch.repeat_interleave(y_encoded, repeats=4, dim=0)
+        x_enc_span = x_encoded.repeat(3, *repeat_idx)
+        y_enc_span = torch.repeat_interleave(y_encoded, repeats=3, dim=0)
 
         bs, c, *img = x.size()
         c_out, c_in, *ks = y.size()
 
-        x_enc_span = x_enc_span.transpose_(0, 1).reshape(bs, 16 * c, *img)
-        y_enc_span = y_enc_span.reshape(16 * c_out, c_in, *ks)
+        x_enc_span = x_enc_span.transpose_(0, 1).reshape(bs, 9 * c, *img)
+        y_enc_span = y_enc_span.reshape(9 * c_out, c_in, *ks)
 
         c_z = c_out if op in ["conv1d", "conv2d"] else c_in
 
         z_encoded = getattr(torch, op)(
-            x_enc_span, y_enc_span, *args, **kwargs, groups=16
+            x_enc_span, y_enc_span, *args, **kwargs, groups=9
         )
-        z_encoded = z_encoded.reshape(bs, 16, c_z, *z_encoded.size()[2:]).transpose_(
+        z_encoded = z_encoded.reshape(bs, 9, c_z, *z_encoded.size()[2:]).transpose_(
             0, 1
         )
 
@@ -211,8 +209,8 @@ class CUDALongTensor(object):
 
         # span x and y for cross multiplication
         repeat_idx = [1] * (x_encoded.dim() - 1)
-        x_enc_span = x_encoded.repeat(4, *repeat_idx)
-        y_enc_span = torch.repeat_interleave(y_encoded, repeats=4, dim=0)
+        x_enc_span = x_encoded.repeat(3, *repeat_idx)
+        y_enc_span = torch.repeat_interleave(y_encoded, repeats=3, dim=0)
 
         for _ in range(abs(x_enc_span.ndim - y_enc_span.ndim)):
             if x_enc_span.ndim > y_enc_span.ndim:


### PR DESCRIPTION
Summary: Instead of breaking a 64 bit integer into 4 16 bit parts, we break it into 3 22 bit parts. We will still have lossless computation while reducing the amount of computation by a factor of 2.

Differential Revision: D22288266

