### PR TITLE
Implement avg_pool2d for CUDALongTensor

### DIFF
--- a/crypten/mpc/primitives/arithmetic.py
+++ b/crypten/mpc/primitives/arithmetic.py
@@ -520,11 +520,10 @@ class ArithmeticSharedTensor(object):
 
     def sum_pool2d(self, *args, **kwargs):
         """Perform a sum pooling on each 2D matrix of the given tensor"""
-        # TODO: Implement avg_pool2d in CUDALongTensor
         result = self.shallow_copy()
         result.share = torch.nn.functional.avg_pool2d(
-            self.share.cpu(), *args, **kwargs, divisor_override=1
-        ).to(self.device)
+            self.share, *args, **kwargs, divisor_override=1
+        )
         return result
 
     def take(self, index, dimension=None):


### PR DESCRIPTION
Summary: There is no CUDA kernel support for `avgpool_2d` for `LongTensor`. In CrypTen, we call `torch.nn.functional.avg_pool2d` on CPU, and then move the result to the specified device. This diff implements `avgpool_2d` in CUDALongTensor so we can directly call this function on GPU.

Differential Revision: D22309739

