### PR TITLE
Restrict autograd backward in accordance with PyTorch

### DIFF
--- a/crypten/cryptensor.py
+++ b/crypten/cryptensor.py
@@ -171,10 +171,14 @@ class CrypTensor(object, metaclass=CrypTensorMetaclass):
                         self.grad.add_(grad_input)  # ... or accumulate gradient...
                     return  # ... and do not proceed.
 
-                # TODO: Remove the default grad_input value currently set to all_ones
                 # if undefined, set gradient input to all ones:
                 if grad_input is None:
-                    grad_input = self.new(torch.ones_like(self.share))
+                    if self.nelement() == 1:
+                        grad_input = torch.ones_like(self.share)
+                    else:
+                        raise RuntimeError(
+                            "grad can be implicitly created only for scalar outputs"
+                        )
 
                 # check that we can actually backpropagate:
                 if self.grad_fn is None:

--- a/crypten/gradients.py
+++ b/crypten/gradients.py
@@ -1593,7 +1593,7 @@ class AutogradBinaryCrossEntropy(AutogradFunction):
         ctx.mark_non_differentiable(target)
         ctx.save_multiple_for_backward([pred, target])
         if skip_forward:
-            return pred.clone()
+            return pred.sub(pred).sum()
 
         # Compute full forward pass
         log_pos, log_neg = crypten.stack([pred, 1.0 - pred]).log().unbind(dim=0)
@@ -1619,7 +1619,7 @@ class AutogradBinaryCrossEntropyWithLogits(AutogradFunction):
         ctx.mark_non_differentiable(target)
         ctx.save_multiple_for_backward([target, sigmoid_out])
         if skip_forward:
-            return sigmoid_out  # TODO: Return None CrypTensor here?
+            return sigmoid_out.sub(sigmoid_out).sum()
 
         # Compute full forward pass
         log_pos, log_neg = (
@@ -1643,7 +1643,7 @@ class AutogradCrossEntropy(AutogradFunction):
         ctx.save_multiple_for_backward([softmax, target])
         ctx.mark_non_differentiable(target)
         if skip_forward:
-            return softmax
+            return softmax.sub(softmax).sum()
 
         # Compute full forward pass
         loss_values = softmax.log().mul_(target).neg_()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -478,7 +478,7 @@ class TestNN(object):
 
                 # test backward pass:
                 reference.backward(torch.ones(reference.size()))
-                encr_output.backward()
+                encr_output.backward(torch.ones(encr_output.size()))
                 if compute_gradients:
                     self._check(
                         encr_input.grad,
@@ -528,7 +528,7 @@ class TestNN(object):
 
                 # test backward pass:
                 reference.backward(torch.ones(reference.size()))
-                encr_output.backward()
+                encr_output.backward(torch.ones(encr_output.size()))
                 if compute_gradients:
                     self._check(
                         encr_input.grad, input.grad, "Linear backward on input failed"


### PR DESCRIPTION
Summary:
Calling `loss.backward()` on a PyTorch tensor will only work without a `grad_input` argument when `loss` is a 1-element tensor. Otherwise it throws an error.

This diff raises the same error for cases where PyTorch would raise the error and handles cases in testing where this was not handled properly.

Differential Revision: D22309803

