### PR TITLE
Cover edge cases of torch.matmul for CUDALongTensor

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -77,15 +77,35 @@ class TestCUDA(TestMPC):
         model.update_parameters(learning_rate=1e-3)
 
     def test_patched_matmul(self):
-        x = get_random_test_tensor(max_value=2 ** 62, is_float=False)
-        x_cuda = CUDALongTensor(x.cuda())
-        for width in range(2, x.nelement()):
-            matrix_size = (x.nelement(), width)
-            y = get_random_test_tensor(
-                size=matrix_size, max_value=2 ** 62, is_float=False
-            )
+        """Test torch.matmul on CUDALongTensor"""
+        input_sizes = [
+            (5,),
+            (5, 5),
+            (5,),
+            (5, 5),
+            (5, 5, 5),
+            (5,),
+            (5, 5, 5, 5),
+            (5, 5),
+        ]
+        other_sizes = [
+            (5,),
+            (5, 5),
+            (5, 5),
+            (5,),
+            (5,),
+            (5, 5, 5),
+            (5, 5),
+            (5, 5, 5, 5),
+        ]
 
+        for x_size, y_size in zip(input_sizes, other_sizes):
+            x = get_random_test_tensor(size=x_size, max_value=2 ** 62, is_float=False)
+            x_cuda = CUDALongTensor(x)
+
+            y = get_random_test_tensor(size=y_size, max_value=2 ** 62, is_float=False)
             y_cuda = CUDALongTensor(y)
+
             z = torch.matmul(x_cuda, y_cuda)
             self.assertTrue(
                 type(z) == CUDALongTensor, "result should be a CUDALongTensor"


### PR DESCRIPTION
Summary:
`torch.matmul` for `CUDALongTensor` fails some corner cases. For example, it does not support `torch.matmul` on two scalar value (dot product). This diff addresses those corner cases so that the behavior of CUDALongTensor's `matmul` matches the original `torch.matmul`.

Here is the description of `torch.matmul` from https://pytorch.org/docs/stable/torch.html?highlight=matmul#torch.matmul
```
Matrix product of two tensors.

The behavior depends on the dimensionality of the tensors as follows:

If both tensors are 1-dimensional, the dot product (scalar) is returned.

If both arguments are 2-dimensional, the matrix-matrix product is returned.

If the first argument is 1-dimensional and the second argument is 2-dimensional, a 1 is prepended to its dimension for the purpose of the matrix multiply. After the matrix multiply, the prepended dimension is removed.

If the first argument is 2-dimensional and the second argument is 1-dimensional, the matrix-vector product is returned.

If both arguments are at least 1-dimensional and at least one argument is N-dimensional (where N > 2), then a batched matrix multiply is returned. If the first argument is 1-dimensional, a 1 is prepended to its dimension for the purpose of the batched matrix multiply and removed after. If the second argument is 1-dimensional, a 1 is appended to its dimension for the purpose of the batched matrix multiple and removed after. The non-matrix (i.e. batch) dimensions are broadcasted (and thus must be broadcastable). For example, if input is a (j \times 1 \times n \times m)(j×1×n×m) tensor and other is a (k \times m \times p)(k×m×p) tensor, out will be an (j \times k \times n \times p)(j×k×n×p) tensor.
```

Differential Revision: D22356414

