### PR TITLE
Add device support for benchmark.py

### DIFF
--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -93,7 +93,6 @@ def resnet18():
 def resnet18_enc():
     model = torch.hub.load("pytorch/vision:v0.5.0", "resnet18", pretrained=True)
     dummy_input = torch.rand([1, 3, 224, 224])
-    crypten.init()
     model_enc = crypten.nn.from_pytorch(model, dummy_input)
     return model_enc
 

--- a/crypten/mpc/mpc.py
+++ b/crypten/mpc/mpc.py
@@ -195,7 +195,10 @@ class MPCTensor(CrypTensor):
             return retval
         else:
             device = input
-            self.share = self.share.to(device)
+            share = self.share.to(device)
+            if share.is_cuda:
+                share = CUDALongTensor(share)
+            self.share = share
             return self
 
     def arithmetic(self):

--- a/examples/multiprocess_launcher.py
+++ b/examples/multiprocess_launcher.py
@@ -56,7 +56,10 @@ class MultiProcessLauncher:
         os.environ["RANK"] = str(rank)
         orig_logging_level = logging.getLogger().level
         logging.getLogger().setLevel(logging.INFO)
-        crypten.init()
+        if hasattr(fn_args, "device"):
+            crypten.init(device=fn_args.device)
+        else:
+            crypten.init()
         logging.getLogger().setLevel(orig_logging_level)
         if fn_args is None:
             run_process_fn()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -77,15 +77,35 @@ class TestCUDA(TestMPC):
         model.update_parameters(learning_rate=1e-3)
 
     def test_patched_matmul(self):
-        x = get_random_test_tensor(max_value=2 ** 62, is_float=False)
-        x_cuda = CUDALongTensor(x.cuda())
-        for width in range(2, x.nelement()):
-            matrix_size = (x.nelement(), width)
-            y = get_random_test_tensor(
-                size=matrix_size, max_value=2 ** 62, is_float=False
-            )
+        """Test torch.matmul on CUDALongTensor"""
+        input_sizes = [
+            (5,),
+            (5, 5),
+            (5,),
+            (5, 5),
+            (5, 5, 5),
+            (5,),
+            (5, 5, 5, 5),
+            (5, 5),
+        ]
+        other_sizes = [
+            (5,),
+            (5, 5),
+            (5, 5),
+            (5,),
+            (5,),
+            (5, 5, 5),
+            (5, 5),
+            (5, 5, 5, 5),
+        ]
 
+        for x_size, y_size in zip(input_sizes, other_sizes):
+            x = get_random_test_tensor(size=x_size, max_value=2 ** 62, is_float=False)
+            x_cuda = CUDALongTensor(x)
+
+            y = get_random_test_tensor(size=y_size, max_value=2 ** 62, is_float=False)
             y_cuda = CUDALongTensor(y)
+
             z = torch.matmul(x_cuda, y_cuda)
             self.assertTrue(
                 type(z) == CUDALongTensor, "result should be a CUDALongTensor"


### PR DESCRIPTION
Summary: Enable benchmarking on GPU. User can specify `--device='cuda'` so that all the benchmarking will be performed on the specified device.

Differential Revision: D22356665

