### PR TITLE
Initialize two sets of generators (for CPU and GPU) at crypten.init()

### DIFF
--- a/crypten/communicator/communicator.py
+++ b/crypten/communicator/communicator.py
@@ -8,6 +8,8 @@
 import logging
 import timeit
 
+import torch
+
 
 class Communicator:
     """
@@ -145,6 +147,50 @@ class Communicator:
 
     def _log_communication_time(self, comm_time):
         self.comm_time += comm_time
+
+    def get_g0(self, device=None):
+        assert hasattr(
+            self, "g0"
+        ), "Generator g0 is not initialized, call crypten.init() first"
+        assert device is None or isinstance(
+            device, (str, torch.device)
+        ), "device must either be a string or a torch.device"
+
+        is_cuda = (isinstance(device, torch.device) and device.type == "cuda") or (
+            isinstance(device, str) and device.startswith("cuda")
+        )
+        if is_cuda:
+            assert (
+                torch.cuda.is_available()
+            ), "Specifying a GPU device but cuda is not available"
+            assert hasattr(
+                self, "g0_cuda"
+            ), "Generator g0_cuda is not initialized, call crypten.init() first"
+            return self.g0_cuda
+
+        return self.g0
+
+    def get_g1(self, device=None):
+        assert hasattr(
+            self, "g1"
+        ), "Generator g1 is not initialized, call crypten.init() first"
+        assert device is None or isinstance(
+            device, (str, torch.device)
+        ), "device must either be a string or a torch.device"
+
+        is_cuda = (isinstance(device, torch.device) and device.type == "cuda") or (
+            isinstance(device, str) and device.startswith("cuda")
+        )
+        if is_cuda:
+            assert (
+                torch.cuda.is_available()
+            ), "Specifying a GPU device but cuda is not available"
+            assert hasattr(
+                self, "g1_cuda"
+            ), "Generator g1_cuda is not initialized, call crypten.init() first"
+            return self.g1_cuda
+
+        return self.g1
 
 
 def _logging(func):

--- a/test/multiprocess_test_case.py
+++ b/test/multiprocess_test_case.py
@@ -184,7 +184,7 @@ class MultiProcessTestCase(unittest.TestCase):
         for key, val in communicator_args.items():
             os.environ[key] = str(val)
 
-        crypten.init(device=self.device)
+        crypten.init()
         self.setUp()
 
         # We're retrieving a corresponding test and executing it.


### PR DESCRIPTION
Summary:
`crypten.init()` takes in a device arguments that specify the device for RNG generators `comm.get().g0` and `comm.get().g1`. This design is not flexible since users can not run their models on CPU if they specify CUDA as device when they call `init()`.

This diff refactor RNG generators to prepare two sets of generators during init, one for CPU and one for GPU. When user run their model on CPU, then generators on CPU will be used, and vice versa.

Differential Revision: D22362004

