### PR TITLE
Fix for _eqz_2PC

### DIFF
--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -635,15 +635,28 @@ class TestMPC(object):
         for _scale in [False, True]:
             for comp in ["gt", "ge", "lt", "le", "eq", "ne"]:
                 for tensor_type in [lambda x: x, MPCTensor]:
-                    tensor = self._get_random_test_tensor(is_float=True)
+                    tensor1 = self._get_random_test_tensor(is_float=True)
                     tensor2 = self._get_random_test_tensor(is_float=True)
 
-                    encrypted_tensor = MPCTensor(tensor)
+                    encrypted_tensor1 = MPCTensor(tensor1)
                     encrypted_tensor2 = tensor_type(tensor2)
 
-                    reference = getattr(tensor, comp)(tensor2).float()
+                    reference = getattr(tensor1, comp)(tensor2).float()
+                    encrypted_out = getattr(encrypted_tensor1, comp)(
+                        encrypted_tensor2, _scale=_scale
+                    )
 
-                    encrypted_out = getattr(encrypted_tensor, comp)(
+                    self._check(encrypted_out, reference, "%s comparator failed" % comp)
+
+                    # Check deterministic example to guarantee all combinations
+                    tensor1 = torch.tensor([2.0, 3.0, 1.0, 2.0, 2.0])
+                    tensor2 = torch.tensor([2.0, 2.0, 2.0, 3.0, 1.0])
+
+                    encrypted_tensor1 = MPCTensor(tensor1)
+                    encrypted_tensor2 = tensor_type(tensor2)
+
+                    reference = getattr(tensor1, comp)(tensor2).float()
+                    encrypted_out = getattr(encrypted_tensor1, comp)(
                         encrypted_tensor2, _scale=_scale
                     )
 


### PR DESCRIPTION
Summary:
Equality was breaking for 2PC when the input values were equal due to improper scaling in the encoder. This was not being caught by the unit test because we used random floating point values, which were essentially never equal.

This diff:
- Corrects the scaling issue in _eqz_2PC
- Adds coverage to the unit test for all equality cases (containing values that are >, =, and <)
- Encorporates the improved _eqz_2PC algorithm into `neq()` as well.

Differential Revision: D22440291

