### PR TITLE
Render GPU benchmark on Dash frontend

### DIFF
--- a/benchmarks/dash_app/app.py
+++ b/benchmarks/dash_app/app.py
@@ -11,6 +11,7 @@ import dash
 import dash_core_components as dcc
 import dash_html_components as html
 import numpy as np
+import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from dash.dependencies import Input, Output
@@ -29,11 +30,13 @@ PATH = pathlib.Path(__file__).parent
 DATA_PATH = PATH.joinpath("data").resolve()
 
 available_dates = get_available_dates(DATA_PATH)
-func_df, model_df = read_data(DATA_PATH, available_dates)
+func_df_cpu, model_df_cpu = read_data(DATA_PATH, available_dates)
+func_df_gpu, model_df_gpu = read_data(DATA_PATH, available_dates, cuda=True)
+func_df = pd.concat([func_df_cpu, func_df_gpu])
+model_df = pd.concat([model_df_cpu, model_df_gpu])
 
+colors_discrete = px.colors.qualitative.Set2
 template = "simple_white"
-green, blue = "#229954", "#1E88E5"
-
 
 # Since we're adding callbacks to elements that don't exist in the app.layout,
 # Dash will raise an exception to warn us that we might be
@@ -106,17 +109,17 @@ index_page = html.Div(
                         html.H3("Functions"),
                         dcc.Markdown(
                             """To reproduce or view assumptions see
-[benchmarks](
-https://github.com/facebookresearch/CrypTen/blob/master/benchmarks/benchmark.py#L68)
-                        """
+                            [benchmarks](
+                            https://github.com/facebookresearch/CrypTen/blob/master/benchmarks/benchmark.py#L68)
+                            """
                         ),
                         html.H5("Runtimes"),
                         dcc.Markdown(
                             """
-* function runtimes are averaged over 10 runs using a random tensor of size (100, 100).
-* `max` and `argmax` are excluded as they take considerably longer.
-    * As of 02/25/2020, `max` / `argmax` take 3min 13s ± 4.73s
-""",
+                            * function runtimes are averaged over 10 runs using a random tensor of size (100, 100).
+                            * `max` and `argmax` are excluded as they take considerably longer.
+                                * As of 02/25/2020, `max` / `argmax` take 3min 13s ± 4.73s
+                            """,
                             className="bullets",
                         ),
                     ]
@@ -137,9 +140,9 @@ https://github.com/facebookresearch/CrypTen/blob/master/benchmarks/benchmark.py#
                 html.H5("Errors"),
                 dcc.Markdown(
                     """
-                * function errors are over the domain (0, 100] with step size 0.01
-                    * exp, sin, and cos are over the domain (0, 10) with step size 0.001
-                """,
+                    * function errors are over the domain (0, 100] with step size 0.01
+                        * exp, sin, and cos are over the domain (0, 10) with step size 0.001
+                    """,
                     className="bullets",
                 ),
                 html.Div(
@@ -159,36 +162,49 @@ https://github.com/facebookresearch/CrypTen/blob/master/benchmarks/benchmark.py#
                         html.H3("Models"),
                         dcc.Markdown(
                             """
-For model details or to reproduce see
-[models](https://github.com/facebookresearch/CrypTen/blob/master/benchmarks/models.py)
-and
-[training details](
-https://github.com/facebookresearch/CrypTen/blob/master/benchmarks/benchmark.py#L293).
-* trained on Gaussian clusters for binary classification
-    * uses SGD with 5k samples, 20 features, over 20 epochs, and 0.1 learning rate
-* feedforward has three hidden layers with intermediary RELU and
-  final sigmoid activations
-* note benchmarks run with world size 1 using CPython
-""",
+                            For model details or to reproduce see
+                            [models](https://github.com/facebookresearch/CrypTen/blob/master/benchmarks/models.py)
+                            and
+                            [training details](
+                            https://github.com/facebookresearch/CrypTen/blob/master/benchmarks/benchmark.py#L293).
+                            * trained on Gaussian clusters for binary classification
+                                * uses SGD with 5k samples, 20 features, over 20 epochs, and 0.1 learning rate
+                            * feedforward has three hidden layers with intermediary RELU and
+                            final sigmoid activations
+                            * note benchmarks run with world size 1 using CPython
+                            """,
                             className="bullets",
                         ),
+                        dcc.Dropdown(
+                            id="select_comparison",
+                            options=[
+                                {"label": comp, "value": comp}
+                                for comp in [
+                                    "CPU vs GPU",
+                                    "CPU vs Plaintext",
+                                    "GPU vs Plaintext",
+                                ]
+                            ],
+                            value="CPU vs GPU",
+                        ),
+                        html.Div(
+                            [
+                                html.Div(
+                                    [dcc.Graph(id="model-training-time")],
+                                    className="six columns",
+                                ),
+                                html.Div(
+                                    [dcc.Graph(id="model-inference-time")],
+                                    className="six columns",
+                                ),
+                                html.Div(
+                                    [dcc.Graph(id="model-accuracy")],
+                                    className="six columns",
+                                ),
+                            ],
+                            className="row",
+                        ),
                     ]
-                ),
-                html.Div(
-                    [
-                        html.Div(
-                            [dcc.Graph(id="model-training-time")],
-                            className="six columns",
-                        ),
-                        html.Div(
-                            [dcc.Graph(id="model-inference-time")],
-                            className="six columns",
-                        ),
-                        html.Div(
-                            [dcc.Graph(id="model-accuracy")], className="six columns"
-                        ),
-                    ],
-                    className="row",
                 ),
             ]
         ),
@@ -275,10 +291,10 @@ comparison_layout = html.Div(
                         ),
                         dcc.Markdown(
                             """
-* function runtimes are averaged over 10 runs using a random tensor of size (100, 100).
-* `max` and `argmax` are excluded as they take considerably longer.
-    * As of 02/25/2020, `max` / `argmax` take 3min 13s ± 4.73s
-""",
+                            * function runtimes are averaged over 10 runs using a random tensor of size (100, 100).
+                            * `max` and `argmax` are excluded as they take considerably longer.
+                                * As of 02/25/2020, `max` / `argmax` take 3min 13s ± 4.73s
+                            """,
                             className="bullets",
                         ),
                     ]
@@ -318,17 +334,21 @@ comparison_layout = html.Div(
 def update_runtime_crypten(selected_date):
     filter_df = func_df[func_df["date"] == selected_date]
     filter_df["runtime in seconds"] = filter_df["runtime crypten"]
+
     fig = px.bar(
         filter_df,
         x="runtime in seconds",
         y="function",
+        color="device",
         orientation="h",
         error_x="runtime crypten error plus",
         error_x_minus="runtime crypten error minus",
-        color_discrete_sequence=[green],
+        color_discrete_sequence=colors_discrete,
         template=template,
         title="Crypten",
+        barmode="group",
     )
+
     fig.update_layout(height=500)
     return fig
 
@@ -342,12 +362,14 @@ def update_runtime_crypten_v_plain(selected_date):
         filter_df,
         x="runtime gap",
         y="function",
+        color="device",
         orientation="h",
         error_x="runtime gap error plus",
         error_x_minus="runtime gap error minus",
-        color_discrete_sequence=[blue],
+        color_discrete_sequence=colors_discrete,
         template=template,
         title="Crypten vs. Plaintext",
+        barmode="group",
     )
 
     fig.update_layout(height=500)
@@ -361,12 +383,14 @@ def update_abs_error(selected_date):
         filter_df,
         x="total abs error",
         text="total abs error",
+        color="device",
         log_x=True,
         y="function",
         orientation="h",
-        color_discrete_sequence=["#C8E6C9"],
+        color_discrete_sequence=colors_discrete,
         template=template,
         title="Crypten Absolute Error",
+        barmode="group",
     )
     fig.update_traces(texttemplate="%{text:.1f}", textposition="outside")
     fig.update_layout(height=500)
@@ -381,29 +405,75 @@ def update_abs_error(selected_date):
         x="average relative error",
         text="average relative error",
         y="function",
+        color="device",
         orientation="h",
-        color_discrete_sequence=["#C8E6C9"],
+        color_discrete_sequence=colors_discrete,
         template=template,
         title="Crypten Relative Error",
+        barmode="group",
     )
     fig.update_traces(texttemplate="%{text:%}", textposition="outside")
     fig.update_layout(height=500)
     return fig
 
 
-@app.callback(Output("model-training-time", "figure"), [Input("select_date", "value")])
-def update_training_time(selected_date):
-    filter_df = model_df[model_df["date"] == selected_date]
-    filter_df["type"] = np.where(filter_df["is plain text"], "Plain Text", "CrypTen")
+def process_comparison_options(filter_df, option):
+    color = "type"
+    if option == "CPU vs Plaintext":
+        filter_df = filter_df[filter_df["device"] == "cpu"]
+        filter_df["type"] = np.where(
+            filter_df["is plain text"], "Plain Text", "CrypTen"
+        )
+    elif option == "GPU vs Plaintext":
+        filter_df = filter_df[filter_df["device"] == "gpu"]
+        if not filter_df.empty:
+            filter_df["type"] = np.where(
+                filter_df["is plain text"], "Plain Text", "CrypTen"
+            )
+    elif option == "CPU vs GPU":
+        color = "device"
+
+    return filter_df, color
+
+
+def render_emtpy_figure():
+    return {
+        "layout": {
+            "xaxis": {"visible": False},
+            "yaxis": {"visible": False},
+            "annotations": [
+                {
+                    "text": "No matching data found",
+                    "xref": "paper",
+                    "yref": "paper",
+                    "showarrow": False,
+                    "font": {"size": 28},
+                }
+            ],
+        }
+    }
+
+
+@app.callback(
+    Output("model-training-time", "figure"),
+    [Input("select_date", "value"), Input("select_comparison", "value")],
+)
+def update_training_time(selected_date, option):
+    filter_df = model_df[(model_df["date"] == selected_date)]
+    filter_df, color = process_comparison_options(filter_df, option)
+
+    if filter_df.empty:
+        return render_emtpy_figure()
+
     fig = px.bar(
         filter_df,
         x="seconds per epoch",
         text="seconds per epoch",
         y="model",
-        color="type",
+        color=color,
         orientation="h",
         barmode="group",
-        color_discrete_sequence=[blue, green],
+        color_discrete_sequence=colors_discrete,
         template=template,
         title="Model Training Time",
     )
@@ -412,19 +482,26 @@ def update_training_time(selected_date):
     return fig
 
 
-@app.callback(Output("model-inference-time", "figure"), [Input("select_date", "value")])
-def update_training_time(selected_date):
-    filter_df = model_df[model_df["date"] == selected_date]
-    filter_df["type"] = np.where(filter_df["is plain text"], "Plain Text", "CrypTen")
+@app.callback(
+    Output("model-inference-time", "figure"),
+    [Input("select_date", "value"), Input("select_comparison", "value")],
+)
+def update_training_time(selected_date, option):
+    filter_df = model_df[(model_df["date"] == selected_date)]
+    filter_df, color = process_comparison_options(filter_df, option)
+
+    if filter_df.empty:
+        return render_emtpy_figure()
+
     fig = px.bar(
         filter_df,
         x="inference time",
         text="inference time",
         y="model",
-        color="type",
+        color=color,
         orientation="h",
         barmode="group",
-        color_discrete_sequence=[blue, green],
+        color_discrete_sequence=colors_discrete,
         template=template,
         title="Model Inference Time",
     )
@@ -436,19 +513,26 @@ def update_training_time(selected_date):
     return fig
 
 
-@app.callback(Output("model-accuracy", "figure"), [Input("select_date", "value")])
-def update_model_accuracy(selected_date):
-    filter_df = model_df[model_df["date"] == selected_date]
-    filter_df["type"] = np.where(filter_df["is plain text"], "Plain Text", "CrypTen")
+@app.callback(
+    Output("model-accuracy", "figure"),
+    [Input("select_date", "value"), Input("select_comparison", "value")],
+)
+def update_model_accuracy(selected_date, option):
+    filter_df = model_df[(model_df["date"] == selected_date)]
+    filter_df, color = process_comparison_options(filter_df, option)
+
+    if filter_df.empty:
+        return render_emtpy_figure()
+
     fig = px.bar(
         filter_df,
         x="accuracy",
         text="accuracy",
         y="model",
-        color="type",
+        color=color,
         orientation="h",
         barmode="group",
-        color_discrete_sequence=[blue, green],
+        color_discrete_sequence=colors_discrete,
         template=template,
         title="Model Accuracy",
     )

--- a/benchmarks/dash_app/load_data.py
+++ b/benchmarks/dash_app/load_data.py
@@ -22,29 +22,44 @@ def get_available_dates(data_dir):
     return available_dates
 
 
-def read_data(data_dir, dates):
+def read_data(data_dir, dates, cuda=False):
     """Builds dataframe for model and func benchmarks Assumes directory is structured as
      DATA_PATH
         |_2020-02-20
             |_func_benchmarks.csv
             |_model_benchmarks.csv
-
+            |_func_benchmarks_cuda.csv (optional)
+            |_model_benchmarks_cuda.csv (optional)
     Args:
         data_dir (pathlib.path): path containing month subdirectories
         dates (list of str): containing dates / subdirectories available
-
     Returns: tuple of pd.DataFrames containing func and model benchmarks with dates
     """
     func_df, model_df = None, None
-
+    postfix = "_cuda" if cuda else ""
     for date in dates:
         path = os.path.join(data_dir, date)
-        tmp_func_df = pd.read_csv(os.path.join(path, "func_benchmarks.csv"))
-        tmp_model_df = pd.read_csv(os.path.join(path, "model_benchmarks.csv"))
-        tmp_func_df["date"], tmp_model_df["date"] = date, date
+
+        func_path = os.path.join(path, f"func_benchmarks{postfix}.csv")
+        model_path = os.path.join(path, f"model_benchmarks{postfix}.csv")
+
+        if os.path.exists(func_path):
+            tmp_func_df = pd.read_csv(func_path)
+            tmp_func_df["date"] = date
+            tmp_func_df["device"] = "gpu" if cuda else "cpu"
+        else:
+            tmp_func_df = None
+
+        if os.path.exists(model_path):
+            tmp_model_df = pd.read_csv(model_path)
+            tmp_model_df["date"] = date
+            tmp_model_df["device"] = "gpu" if cuda else "cpu"
+        else:
+            tmp_model_df = None
+
         if func_df is None:
-            func_df = tmp_func_df.copy()
-            model_df = tmp_model_df.copy()
+            func_df = tmp_func_df.copy() if tmp_func_df is not None else None
+            model_df = tmp_model_df.copy() if tmp_model_df is not None else None
         else:
             func_df = func_df.append(tmp_func_df)
             model_df = model_df.append(tmp_model_df)


### PR DESCRIPTION
Summary:
Render GPU benchmark on the Dash app.
This diff makes the following change:
1. modify `read_data()` to handle `{}_benchmarks_cuda.csv` that potentially does not exist.
2. For function benchmarks, render GPU runtime and CPU runtime side by side
3. For model benchmarks, add a dropdown menu that allows us to select comparison options among "CPU vs Plaintext", "GPU vs Plaintext", and "CPU vs GPU"

{F243561620}

{F243561621}

Differential Revision: D22447274

