### PR TITLE
Enable TTP for benchmarking

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -580,6 +580,14 @@ def get_args():
         help="use different gpu for each party. Will override --device if selected",
     )
     parser.add_argument(
+        "--ttp",
+        "-ttp",
+        required=False,
+        default=False,
+        action="store_true",
+        help="initialize a trusted third party (TTP) as beaver triples' provider, world_size should be greater than 2",
+    )
+    parser.add_argument(
         "--advanced-models",
         required=False,
         default=False,
@@ -633,6 +641,8 @@ def main():
         benchmarks = [FuncBenchmarks(device=device)]
 
     if args.world_size > 1:
+        if args.ttp:
+            crypten.mpc.set_default_provider("TTP")
         launcher = multiprocess_launcher.MultiProcessLauncher(
             args.world_size, multiprocess_caller, fn_args=args
         )

--- a/crypten/mpc/__init__.py
+++ b/crypten/mpc/__init__.py
@@ -46,6 +46,7 @@ def set_default_provider(new_default_provider):
     assert_msg = "Provider %s is not supported" % new_default_provider
     if isinstance(new_default_provider, str):
         assert new_default_provider in __SUPPORTED_PROVIDERS.keys(), assert_msg
+        new_default_provider = __SUPPORTED_PROVIDERS[new_default_provider]
     else:
         assert new_default_provider in __SUPPORTED_PROVIDERS.values(), assert_msg
     __default_provider = new_default_provider


### PR DESCRIPTION
Summary: Add an option to use TTP as the backend in `benchmark.py`. Also, fix a bug in `set_default_provider()` so that it can take in a string (e.g "TTP") to represent the backend.

Differential Revision: D22466783

