### PR TITLE
Make benchmark.py backward compatible

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -111,9 +111,9 @@ class FuncBenchmarks:
     # for exponential, sin, and cos
     TRUNCATED_DOMAIN = torch.arange(start=0.001, end=10, step=0.001)
 
-    def __init__(self, tensor_size=(100, 100), device="cpu"):
-        self.device = torch.device(device)
+    def __init__(self, tensor_size=(100, 100), device=None):
         self.tensor_size = tensor_size
+        self.device = torch.device(device)
 
         # dataframe for benchmarks
         self.df = None
@@ -237,10 +237,11 @@ class FuncBenchmarks:
             FuncBenchmarks.DOMAIN,
             FuncBenchmarks.TRUNCATED_DOMAIN,
         )
-        DOMAIN, TRUNCATED_DOMAIN = (
-            DOMAIN.to(device=self.device),
-            TRUNCATED_DOMAIN.to(device=self.device),
-        )
+        if hasattr(DOMAIN, "to") and hasattr(TRUNCATED_DOMAIN, "to"):
+            DOMAIN, TRUNCATED_DOMAIN = (
+                DOMAIN.to(self.device),
+                TRUNCATED_DOMAIN.to(self.device),
+            )
         y = torch.rand(DOMAIN.shape, device=self.device)
         DOMAIN_enc, y_enc = crypten.cryptensor(DOMAIN), crypten.cryptensor(y)
         TRUNCATED_DOMAIN_enc = crypten.cryptensor(TRUNCATED_DOMAIN)
@@ -338,9 +339,9 @@ class ModelBenchmarks:
         lr_rate (float): learning rate.
     """
 
-    def __init__(self, device="cpu", advanced_models=False):
-        self.device = torch.device(device)
+    def __init__(self, device=None, advanced_models=False):
         self.df = None
+        self.device = torch.device(device)
         self.models = models.MODELS
         if not advanced_models:
             self.remove_advanced_models()
@@ -416,14 +417,22 @@ class ModelBenchmarks:
 
         for model in self.models:
             x, y = model.data.x, model.data.y
-            x, y = x.to(device=self.device), y.to(device=self.device)
-            model_plain = model.plain().to(device=self.device)
+            x, y = x.to(self.device), y.to(self.device)
+            model_plain = model.plain()
+            if hasattr(model_plain, "to"):
+                model_plain = model_plain.to(self.device)
+
             runtime, _ = self.train(model_plain, x, y, 1, model.lr, model.loss)
             runtimes.append(runtime)
 
-            x_enc = crypten.cryptensor(x, device=self.device)
-            y_enc = crypten.cryptensor(y, device=self.device)
-            model_enc = model.crypten().to(device=self.device).encrypt()
+            x_enc = crypten.cryptensor(x)
+            y_enc = crypten.cryptensor(y)
+
+            model_crypten = model.crypten()
+            if hasattr(model_crypten, "to"):
+                model_crypten = model_crypten.to(self.device)
+            model_enc = model_crypten.encrypt()
+
             runtime_enc, _ = self.train_crypten(
                 model_enc, x_enc, y_enc, 1, model.lr, model.loss
             )
@@ -442,13 +451,19 @@ class ModelBenchmarks:
         runtimes_enc = []
 
         for model in self.models:
-            model_plain = model.plain().to(device=self.device)
-            runtime, _ = self.predict(model_plain, model.data.x.to(device=self.device))
+            x = model.data.x.to(self.device)
+            model_plain = model.plain()
+            if hasattr(model_plain, "to"):
+                model_plain = model_plain.to(self.device)
+            runtime, _ = self.predict(model_plain, x)
             runtimes.append(runtime)
 
-            model_enc = model.crypten()
-            model_enc = model_enc.to(device=self.device).encrypt()
-            x_enc = crypten.cryptensor(model.data.x, device=self.device)
+            model_crypten = model.crypten()
+            if hasattr(model_crypten, "to"):
+                model_crypten = model_crypten.to(self.device)
+            model_enc = model_crypten.encrypt()
+
+            x_enc = crypten.cryptensor(x)
             runtime_enc, _ = self.predict(model_enc, x_enc)
             runtimes_enc.append(runtime_enc)
 
@@ -468,7 +483,7 @@ class ModelBenchmarks:
         output, y = output.cpu(), y.cpu()
         predicted = (output > threshold).float()
         correct = (predicted == y).sum().float()
-        accuracy = float((correct / y.shape[0]).numpy())
+        accuracy = float((correct / y.shape[0]).cpu().numpy())
         return accuracy
 
     def evaluate(self):
@@ -476,26 +491,31 @@ class ModelBenchmarks:
         accuracies, accuracies_crypten = [], []
 
         for model in self.models:
-            model_plain = model.plain().to(device=self.device)
+            model_plain = model.plain()
+            if hasattr(model_plain, "to"):
+                model_plain = model_plain.to(self.device)
             x, y = model.data.x, model.data.y
-            x, y = x.to(device=self.device), y.to(device=self.device)
+            x, y = x.to(self.device), y.to(self.device)
             _, model_plain = self.train(
                 model_plain, x, y, model.epochs, model.lr, model.loss
             )
 
-            x_test = model.data.x_test.to(device=self.device)
-            y_test = model.data.y_test.to(device=self.device)
+            x_test = model.data.x_test.to(self.device)
+            y_test = model.data.y_test.to(self.device)
             accuracy = ModelBenchmarks.calc_accuracy(model_plain(x_test), y_test)
             accuracies.append(accuracy)
 
             model_crypten = model.crypten()
-            model_crypten = model_crypten.to(device=self.device).encrypt()
-            x_enc = crypten.cryptensor(x, device=self.device)
-            y_enc = crypten.cryptensor(y, device=self.device)
+            if hasattr(model_crypten, "to"):
+                model_crypten = model_crypten.to(self.device)
+            model_crypten = model_crypten.encrypt()
+            x_enc = crypten.cryptensor(x)
+            y_enc = crypten.cryptensor(y)
             _, model_crypten = self.train_crypten(
                 model_crypten, x_enc, y_enc, model.epochs, model.lr, model.loss
             )
-            x_test_enc = crypten.cryptensor(model.data.x_test, device=self.device)
+            x_test = model.data.x_test.to(self.device)
+            x_test_enc = crypten.cryptensor(model.data.x_test)
 
             output = model_crypten(x_test_enc).get_plain_text()
             accuracy = ModelBenchmarks.calc_accuracy(output, y_test)
@@ -632,6 +652,13 @@ def main():
     args = get_args()
     device = torch.device(args.device)
 
+    if not hasattr(crypten.nn.Module, "to") or not hasattr(crypten.mpc.MPCTensor, "to"):
+        if device.type == "cuda":
+            print(
+                "GPU computation is not supported for this version of CrypTen, benchmark will be skipped"
+            )
+            return
+
     benchmarks = [
         FuncBenchmarks(device=device),
         ModelBenchmarks(device=device, advanced_models=args.advanced_models),
@@ -642,7 +669,7 @@ def main():
 
     if args.world_size > 1:
         if args.ttp:
-            crypten.mpc.set_default_provider("TTP")
+            crypten.mpc.set_default_provider(crypten.mpc.provider.TrustedThirdParty)
         launcher = multiprocess_launcher.MultiProcessLauncher(
             args.world_size, multiprocess_caller, fn_args=args
         )

--- a/benchmarks/run_historical_benchmarks.py
+++ b/benchmarks/run_historical_benchmarks.py
@@ -29,18 +29,24 @@ import subprocess
 from dateutil.relativedelta import relativedelta
 
 
-def parse_overwrite():
+def parse_args():
     """Parses command line arguments"""
     parser = argparse.ArgumentParser(description="Run Historical Benchmarks")
     parser.add_argument(
         "--overwrite",
-        type=bool,
         required=False,
         default=False,
+        action="store_true",
         help="overwrite existing data directories",
     )
+    parser.add_argument(
+        "--cuda-toolkit-version",
+        required=False,
+        default="10.1",
+        help="build pytorch with the corresponding version of cuda-toolkit",
+    )
     args = parser.parse_args()
-    return args.overwrite
+    return args
 
 
 def get_dates(day=26):
@@ -66,7 +72,9 @@ def get_dates(day=26):
     return dates
 
 
-overwrite = parse_overwrite()
+args = parse_args()
+overwrite = args.overwrite
+cuda_version = "".join(args.cuda_toolkit_version.split("."))
 dates = get_dates()
 PATH = os.getcwd()
 
@@ -77,18 +85,19 @@ subprocess.call(
 )
 
 # create venv
-subprocess.call("cd /tmp && python -m venv .venv", shell=True)
-venv = "cd /tmp && source .venv/bin/activate && "
+subprocess.call("cd /tmp && python3 -m venv .venv", shell=True)
+venv = "cd /tmp && . .venv/bin/activate && "
 
 # install PyTorch
 subprocess.call(
-    f"{venv} pip install onnx==1.6.0 tensorboard pandas sklearn", shell=True
+    f"{venv} pip3 install onnx==1.6.0 tensorboard pandas sklearn", shell=True
 )
-nightly = "dev20200220"
-nightly_url = "https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html"
-pip_torch = f"pip install torch==1.5.0.{nightly} torchvision==0.6.0.{nightly}"
-subprocess.call(f"{venv} {pip_torch} -f {nightly_url}", shell=True)
+stable_url = "https://download.pytorch.org/whl/torch_stable.html"
+pip_torch = f"pip install torch==1.5.1+{cuda_version} torchvision==0.6.1+{cuda_version} -f https://download.pytorch.org/whl/torch_stable.html"
+subprocess.call(f"{venv} {pip_torch} -f {stable_url}", shell=True)
 
+
+modes = {"1pc": "", "2pc": "--world-size=2", "2pc/ttp": "--world-size=2 --ttp"}
 
 for date in dates:
     path_exists = os.path.exists(f"dash_app/data/{date}/func_benchmarks.csv")
@@ -100,12 +109,18 @@ for date in dates:
         + f"git checkout `git rev-list -n 1 --before='{date} 01:01' master`",
         shell=True,
     )
-    subprocess.call(venv + "pip install CrypTen/.", shell=True)
-    subprocess.call(f"echo Generating {date} Benchmarks", shell=True)
-    subprocess.call(f"mkdir -p dash_app/data/{date}", shell=True)
-    path = os.path.join(PATH, f"dash_app/data/{date}")
-    subprocess.call(venv + f"cd {PATH} && python benchmark.py -p '{path}'", shell=True)
-
+    for mode, arg in modes.items():
+        subprocess.call(venv + "pip3 install CrypTen/.", shell=True)
+        subprocess.call(f"echo Generating {date} Benchmarks for {mode}", shell=True)
+        path = os.path.join(PATH, f"dash_app/data/{date}", mode)
+        subprocess.call(f"mkdir -p {path}", shell=True)
+        subprocess.call(
+            venv + f"cd {PATH} && python3 benchmark.py -p '{path}' {arg}", shell=True
+        )
+        subprocess.call(
+            venv + f"cd {PATH} && python3 benchmark.py -p '{path}' -d 'cuda' {arg}",
+            shell=True,
+        )
 
 # clean up
 shutil.rmtree("/tmp/.venv", ignore_errors=True)


### PR DESCRIPTION
Summary:
This diff does the following thing:

1. Make `benchmark.py` backward compatible. Specifically, skip running `crypten_model.to()` if historical CrypTen version does not have API support for it.
2. Modify `run_historical_benchmark.py` to generate data for 2PC case. Results will be stored in the subfolder `{date}/2pc`.

Differential Revision: D22511309

