### PR TITLE
Disable tracking of computations on CrypTensors for which requires_grad is False

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -194,6 +194,32 @@ class TestAutograd(object):
             self.assertIsNone(input1.grad, msg)
             self.assertIsNotNone(input2.grad, msg)
 
+    def test_forward_tracking(self):
+        """Tests that requires_grad influences tracking of forward computations."""
+
+        for requires_grad in [True, False]:
+
+            # get test case:
+            input = get_random_test_tensor(size=(12, 5), is_float=True)
+            input = crypten.cryptensor(input, requires_grad=requires_grad)
+
+            # perform forward computation:
+            output = input.exp().sum()
+
+            # setting requires_grad post-hoc should not affect backward behavior:
+            input.requires_grad = True
+            output.requires_grad = True
+            output.backward()
+
+            # check results:
+            msg = "tracking of forward computations does not work as expected"
+            if requires_grad:
+                self.assertIsNotNone(input.grad, msg)
+                self.assertIsNone(output.grad, msg)
+            else:
+                self.assertIsNone(input.grad, msg)
+                self.assertIsNotNone(output.grad, msg)
+
     def test_autograd_accumulation(self):
         """Tests accumulation in autograd."""
 


### PR DESCRIPTION
Summary:
When `CrypTensor.requires_grad` is `False`, we are currently still storing some information: namely, we are storing a nearly empty `res` object in `self.parents`. This leads to an accumulation of data that is not removed because the user never calls `backward()` (see D21644543 and P131496553).

This diff makes sure no information is stored during forward computations with `CrypTensor`s on which `requires_grad` is `False`.

Note that this does lead to behavior change: it is no longer possible to change the `requires_grad` value to `True` *after* a forward computation has been performed to still obtain the gradient on that tensor. This behavior appears to be in line with the behavior of the PyTorch autograd, which does not seem to be taking forward computations on tensors unless `requires_grad` is `True` either:
```
>>> a = torch.randn(5)
>>> b = a.exp().sum()
>>> a.requires_grad = True
>>> b.requires_grad = True
>>> b.backward()
>>> a.grad
>>> print(a.grad)
None
>>> b.grad
tensor(1.)
```

The diff also fixes a small issue where running `t.backward()` on a `CrypTensor` of size 1 with `requires_grad=True` did not set `t.grad` to 1 (akin to the PyTorch example above). I have added a unit test that locks in these behavior changes.

Differential Revision: D22509857

