### PR TITLE
Fix tensorflow Conv2d Onnx Import

### DIFF
--- a/crypten/nn/onnx_converter.py
+++ b/crypten/nn/onnx_converter.py
@@ -161,6 +161,7 @@ class FromOnnx:
 
             crypten_class = self._get_operator_class(node.op_type, attributes)
 
+            parameters = _sync_tensorflow_parameters(parameters, node.op_type)
             # add CrypTen module to graph
             crypten_module = crypten_class.from_onnx(
                 parameters=parameters, attributes=attributes
@@ -322,7 +323,10 @@ def _sync_tensorflow_parameters(parameter_map, module_name):
 
     new_parameter_map = {}
     if module_name == "Conv":
-        module_param_names = ["weight", "bias"]
+        module_param_names = [
+            "weight",
+            "bias",
+        ]
         _map_module_parameters(parameter_map, module_param_names)
     elif module_name == "BatchNormalization":
         module_param_names = [

--- a/test/test_onnx_converter.py
+++ b/test/test_onnx_converter.py
@@ -162,9 +162,8 @@ class TestOnnxConverter(object):
             graph_def, inputs, outputs = tf2onnx.tf_loader.from_saved_model(
                 saved_model_dir, None, None
             )
-            model_enc = crypten.nn.from_tensorflow(
-                graph_def, list(inputs.keys()), list(outputs.keys())
-            )
+
+            model_enc = crypten.nn.from_tensorflow(graph_def, inputs, outputs)
 
             # encrypt model and run it
             model_enc.encrypt()


### PR DESCRIPTION
Fixes tensorflow Conv2D Onnx conversion: 

* Adds call to `sync_tensorflow_parameters`
* Directly passes `inputs` and `outputs` in tests (due to a change in type)


## Types of changes


- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue
Circle CI test failure
## How Has This Been Tested (if it applies)

`python -m unittest test.test_onnx_converter.TestTTP.test_tensorflow_model_conversion`

## Checklist

- [X] The documentation is up-to-date with the changes I made.
- [X] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ X] All tests passed, and additional code has been covered with new tests.
