### PR TITLE
Fix TFE Network C Dimension

### DIFF
--- a/examples/tfe_benchmarks/tfe_benchmarks.py
+++ b/examples/tfe_benchmarks/tfe_benchmarks.py
@@ -452,7 +452,7 @@ class NetworkC(nn.Module):
         out = self.batchnorm2(out)
         out = F.relu(out)
         out = F.avg_pool2d(out, 2)
-        out = out.view(-1, 16 * 4 * 4)
+        out = out.view(-1, 50 * 4 * 4)
         out = self.fc1(out)
         out = self.batchnorm3(out)
         out = F.relu(out)


### PR DESCRIPTION
Summary: Fixes dimension of input into fully connected layer (for TFE example with Network C). This was test failure was previously hidden by other Circle CI errors.

Differential Revision: D22734558

