### PR TITLE
Bind module parameters to attributes

### DIFF
--- a/crypten/nn/module.py
+++ b/crypten/nn/module.py
@@ -508,6 +508,9 @@ class Module:
             modules[name] = value
         else:
             object.__setattr__(self, name, value)
+            parameters = self.__dict__.get("_parameters")
+            if parameters is not None and name in parameters:
+                parameters[name] = value
 
 
 class Container(Module):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -719,6 +719,14 @@ class TestNN(object):
         self.assertTrue(
             isinstance(model.fc1, crypten.nn.Linear), "modules __getattr__ failed"
         )
+        model.fc1.weight = torch.nn.Parameter(torch.zeros((2, 3)))
+        self.assertTrue(
+            torch.all(
+                model.fc1._parameters["weight"].eq(
+                    torch.nn.Parameter(torch.zeros((2, 3)))
+                )
+            )
+        )
 
     def test_training(self):
         """


### PR DESCRIPTION
Summary:
Add a piece of code to update the corresponding item in _parameters in line 511@module.py

Add a test in line 722@test_nn.py to make sure assignment to model.weight is reflected when accessing model._parameters["weight].

Differential Revision: D22772968

