### PR TITLE
Fix autograd issue when node has multiple parents

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -249,8 +249,58 @@ class TestAutograd(object):
             encr_output = encr_intermediate2.square().sum()
             return output, encr_output
 
+        def test_case4(input, encr_input):
+            intermediate1 = input.mul(3.0).add(2.0).pow(2.0)  # PyTorch
+            intermediate2 = intermediate1.add(1.0).add(intermediate1.mul(2.0))
+            output = intermediate2.pow(2.0).sum()
+            encr_intermediate1 = encr_input.mul(3.0).add(2.0).square()  # CrypTen
+            encr_intermediate2 = encr_intermediate1.add(1.0).add(
+                encr_intermediate1.mul(2.0)
+            )
+            encr_output = encr_intermediate2.square().sum()
+            return output, encr_output
+
+        def test_case5(input, encr_input):
+            intermediate1 = input.mul(3.0)  # PyTorch
+            intermediate2 = input.add(2.0).pow(2.0)
+            intermediate3 = input.pow(2.0)
+            output = (
+                torch.cat([intermediate1, intermediate2, intermediate3]).mul(0.5).sum()
+            )
+            encr_intermediate1 = encr_input.mul(3.0)  # CrypTen
+            encr_intermediate2 = encr_input.add(2.0).square()
+            encr_intermediate3 = encr_input.pow(2.0)
+            encr_output = (
+                crypten.cat(
+                    [encr_intermediate1, encr_intermediate2, encr_intermediate3]
+                )
+                .mul(0.5)
+                .sum()
+            )
+            return output, encr_output
+
+        def test_case6(input, encr_input):
+            idx1 = torch.tensor([[0, 2, 4, 3, 8]], dtype=torch.long)
+            idx2 = torch.tensor([[5, 1, 3, 5, 2]], dtype=torch.long)
+            idx3 = torch.tensor([[2, 3, 1]], dtype=torch.long)
+            intermediate1 = input.gather(0, idx1).gather(1, idx3).pow(2.0)  # PyTorch
+            intermediate2 = input.gather(0, idx2).gather(1, idx3).add(-2.0)
+            output = torch.cat([intermediate1, intermediate2]).mul(0.5).sum()
+            encr_intermediate1 = (
+                encr_input.gather(0, idx1).gather(1, idx3).square()
+            )  # CrypTen
+            encr_intermediate2 = encr_input.gather(0, idx2).gather(1, idx3).add(-2.0)
+            encr_output = (
+                crypten.cat([encr_intermediate1, encr_intermediate2], dim=0)
+                .mul(0.5)
+                .sum()
+            )
+            return output, encr_output
+
         # loop over test cases:
-        for idx, test_case in enumerate([test_case1, test_case2, test_case2]):
+        for idx, test_case in enumerate(
+            [test_case1, test_case2, test_case3, test_case4, test_case5, test_case6]
+        ):
 
             # get input tensors:
             input = get_random_test_tensor(size=(12, 5), is_float=True)


### PR DESCRIPTION
Summary:
When a node in the backwards pass has multiple parents, the current autograd implementation does not accumulate the gradients coming from those parents. This diff addresses that issue.

Curiously, the unit tests had tests for this issue, but for some reason they did not fire. I have confirmed that the tests run, and added some additional test cases.

Differential Revision: D23287670

