### PR TITLE
Support calling torch.{cat,stack} on CrypTensors

### DIFF
--- a/test/test_crypten.py
+++ b/test/test_crypten.py
@@ -57,15 +57,18 @@ class TestCrypten(MultiProcessTestCase):
         encrypted1 = crypten.cryptensor(tensor1)
         encrypted2 = crypten.cryptensor(tensor2)
 
-        for op in ["cat", "stack"]:
-            reference = getattr(torch, op)([tensor1, tensor2])
-            encrypted_out = getattr(crypten, op)([encrypted1, encrypted2])
-            self._check(encrypted_out, reference, "%s failed" % op)
-
-            for dim in range(4):
-                reference = getattr(torch, op)([tensor1, tensor2], dim=dim)
-                encrypted_out = getattr(crypten, op)([encrypted1, encrypted2], dim=dim)
+        for module in [crypten, torch]:  # torch.cat on CrypTensor runs crypten.cat
+            for op in ["cat", "stack"]:
+                reference = getattr(torch, op)([tensor1, tensor2])
+                encrypted_out = getattr(module, op)([encrypted1, encrypted2])
                 self._check(encrypted_out, reference, "%s failed" % op)
+
+                for dim in range(4):
+                    reference = getattr(torch, op)([tensor1, tensor2], dim=dim)
+                    encrypted_out = getattr(module, op)(
+                        [encrypted1, encrypted2], dim=dim
+                    )
+                    self._check(encrypted_out, reference, "%s failed" % op)
 
     def test_rand(self):
         """Tests uniform random variable generation on [0, 1)"""


### PR DESCRIPTION
Summary: At present, it is somewhat tricky to write code that works both with PyTorch and with CrypTen tensors because static functions like `torch.cat` do not work on CrypTen tensors (and vice versa). This diff addresses this problem by allowing users to call `torch.{cat,stack}(list_of_cryptensors)`. Calls are dispatched to CrypTen and go through the CrypTen autograd as expected.

Differential Revision: D23668830

