### PR TITLE
Implement recursive `module()` and non-recursive `children` similar to PyTorch's API

### DIFF
--- a/crypten/cuda/cuda_tensor.py
+++ b/crypten/cuda/cuda_tensor.py
@@ -478,6 +478,9 @@ class CUDALongTensor(object):
     def __ge__(self, y):
         return CUDALongTensor(self._tensor >= y)
 
+    def __hash__(self):
+        return hash(self._tensor)
+
     def lshift_(self, value):
         """Right shift elements by `value` bits"""
         assert isinstance(value, int), "lshift must take an integer argument."

--- a/crypten/mpc/mpc.py
+++ b/crypten/mpc/mpc.py
@@ -302,6 +302,9 @@ class MPCTensor(CrypTensor):
             value = MPCTensor(value, ptype=self.ptype, device=self.device)
         self._tensor.__setitem__(index, value._tensor)
 
+    def __hash__(self):
+        return hash(self.share)
+
     @property
     def share(self):
         """Returns underlying share"""

--- a/crypten/nn/module.py
+++ b/crypten/nn/module.py
@@ -169,19 +169,6 @@ class Module:
         self._parameters[name] = cls.from_shares(share, **kwargs)
         setattr(self, name, self._parameters[name])
 
-    def _named_members(self, get_members_fn, prefix='', recurse=True):
-        """Helper method for yielding various names + members of modules."""
-        memo = set()
-        modules = self.named_modules(prefix=prefix) if recurse else [(prefix, self)]
-        for module_prefix, module in modules:
-            members = get_members_fn(module)
-            for k, v in members:
-                if v is None or v in memo:
-                    continue
-                memo.add(v)
-                name = module_prefix + ('.' if module_prefix else '') + k
-                yield name, v
-
     def parameters(self, recurse=True):
         """Returns an iterator over module parameters.
         This is typically passed to an optimizer.
@@ -207,12 +194,6 @@ class Module:
         Yields:
             (string, CrypTensor or torch.Tensor): Tuple containing the name and parameter
         """
-        # gen = self._named_members(
-        #     lambda module: module._parameters.items(),
-        #     prefix=prefix, recurse=recurse)
-        # for elem in gen:
-        #     yield elem
-
         for name, param in self._parameters.items():
             param_name = name if prefix is None else prefix + "." + name
             yield param_name, param

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -456,7 +456,7 @@ class TestNN(object):
                     if hasattr(module, key):  # if PyTorch model has key
                         # find that key in the crypten.nn.Graph:
                         if isinstance(encr_module, crypten.nn.Graph):
-                            for encr_node in encr_module.modules():
+                            for encr_node in encr_module.children():
                                 if hasattr(encr_node, key):
                                     encr_param = getattr(encr_node, key)
                                     break
@@ -584,9 +584,9 @@ class TestNN(object):
 
                 # check container:
                 self.assertTrue(sequential.encrypted, "nn.Sequential not encrypted")
-                for module in sequential.modules():
+                for module in sequential.children():
                     self.assertTrue(module.encrypted, "module not encrypted")
-                assert sum(1 for _ in sequential.modules()) == len(
+                assert sum(1 for _ in sequential.children()) == len(
                     module_list
                 ), "nn.Sequential contains incorrect number of modules"
 
@@ -598,7 +598,7 @@ class TestNN(object):
 
                 # compute reference output:
                 encr_reference = encr_input
-                for module in sequential.modules():
+                for module in sequential.children():
                     encr_reference = module(encr_reference)
                 reference = encr_reference.get_plain_text()
 
@@ -632,10 +632,10 @@ class TestNN(object):
 
             # check container:
             self.assertTrue(graph.encrypted, "nn.Graph not encrypted")
-            for module in graph.modules():
+            for module in graph.children():
                 self.assertTrue(module.encrypted, "module not encrypted")
             assert (
-                sum(1 for _ in graph.modules()) == 3
+                sum(1 for _ in graph.children()) == 3
             ), "nn.Graph contains incorrect number of modules"
 
             # compare output to reference:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
CryTen Module's `module()` and `named_module`() functions are not akin to PyTorch. In PyTorch, these two functions will yield modules recursively. The current implementation is non-recursive, which is akin to the `children()` and `named_children()` functions in PyTorch. This PR will implement `module()` recursively and  move the non-recursive version to `children`

## How Has This Been Tested (if it applies)
python -m test.test_nn

The test_pytorch_module test did not with the error message `RuntimeError: ONNX export failed: Couldn't export operator aten::adaptive_avg_pool2d`. I think this error is not caused by this PR.
<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
