### PR TITLE
Raise RuntimeError when trying to use in-place functions in autograd

### DIFF
--- a/crypten/gradients.py
+++ b/crypten/gradients.py
@@ -36,11 +36,14 @@ def register_function(name):
 def get_grad_fn(name):
     """
     Returns gradient function for the CrypTen function with the specified name.
+    Also returns a boolean indicating whether or not the function is in-place.
     """
     if name in FUNCTION_REGISTRY:
-        return FUNCTION_REGISTRY[name]
-    else:
-        return None
+        return FUNCTION_REGISTRY[name], False
+    elif name.endswith("_"):
+        if name[:-1] in FUNCTION_REGISTRY:  # this is an in-place function
+            return FUNCTION_REGISTRY[name[:-1]], True
+    return None, False
 
 
 def _ensure_tensor(input):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -106,27 +106,46 @@ class TestAutograd(object):
                 "value of requires_grad is incorrect",
             )
 
+    def test_inplace(self):
+        """
+        Tests that in-place functions cannot be used in autograd but return
+        correct results outside of autograd.
+        """
+        value = 1.5
+        reference = get_random_test_tensor(size=(1, 3, 8, 8), is_float=True)
+        for requires_grad in [False, True]:
+            result = crypten.cryptensor(reference, requires_grad=requires_grad)
+            if requires_grad:
+                with self.assertRaises(RuntimeError):
+                    result.add_(value)
+            else:
+                result.add_(value)
+                self._check(result, reference.add(value), "in-place addition failed")
+
     def test_autograd_registation(self):
         """Tests registration of new autograd function."""
 
         # check that get_grad_fn() returns correct functions:
         for func_name, reference_func in gradients.FUNCTION_REGISTRY.items():
-            grad_fn = gradients.get_grad_fn(func_name)
+            grad_fn, in_place = gradients.get_grad_fn(func_name)
             self.assertEqual(grad_fn, reference_func)
             self.assertEqual(grad_fn.name, func_name)
+            self.assertFalse(in_place)
 
         # check that non-existing functions return None:
         for invalid_func_name in ["bfobofb", "djhfhr"]:
-            func = gradients.get_grad_fn(invalid_func_name)
+            func, in_place = gradients.get_grad_fn(invalid_func_name)
             self.assertIsNone(func)
+            self.assertFalse(in_place)
 
         # check that registering new classes works:
         for func_name in ["mock_func1", "mock_func2", "mock_func3"]:
             cls = type("%sName" % func_name, (AutogradFunction,), {})
             gradients.register_function(func_name)(cls)
-            grad_fn = gradients.get_grad_fn(func_name)
+            grad_fn, in_place = gradients.get_grad_fn(func_name)
             self.assertEqual(grad_fn, cls)
             self.assertEqual(grad_fn.name, func_name)
+            self.assertFalse(in_place)
 
         # check that existing functions cannot be overwritten:
         for func_name in ["add", "sub", "view"]:
@@ -148,7 +167,7 @@ class TestAutograd(object):
 
             # test forward
             ctx = AutogradContext()
-            grad_fn_take = gradients.get_grad_fn("take")
+            grad_fn_take, _ = gradients.get_grad_fn("take")
             encr_output = grad_fn_take.forward(ctx, *encr_inputs)
             self._check(encr_output, ref_forward, "take forward failed: dimension set")
 

--- a/test/test_gradients.py
+++ b/test/test_gradients.py
@@ -759,7 +759,7 @@ class TestGradients:
                 # compute CrypTen output:
                 encrypted_input.requires_grad = True
                 ctx = AutogradContext()
-                batch_norm_fn = crypten.gradients.get_grad_fn("batchnorm")
+                batch_norm_fn, _ = crypten.gradients.get_grad_fn("batchnorm")
                 encrypted_out = batch_norm_fn.forward(
                     ctx,
                     encrypted_input,


### PR DESCRIPTION
Summary:
At present, the autograd logic performs in-place functions on `CrypTensor`s for which `requires_grad == True` without keeping track of the in-place operation. This is dangerous and can lead to unexpected behaviors.

After looking into PyTorch's logic for dealing with in-place functions in autograd, I decided the effort needed to support this in CrypTen would be substantial and the advantages would be limited.

This diff makes sure a `RunTimeError` is raised whenever the user performs an in-place operation on a tensor that is tracked by the autograd.

Differential Revision: D24385646

