### PR TITLE
Fix communication primitives and random sampling on GPU

### DIFF
--- a/crypten/mpc/mpc.py
+++ b/crypten/mpc/mpc.py
@@ -365,7 +365,9 @@ class MPCTensor(CrypTensor):
         """
         rand = MPCTensor([])
         encoder = FixedPointEncoder()
-        rand._tensor = BinarySharedTensor.rand(*sizes, bits=encoder._precision_bits)
+        rand._tensor = BinarySharedTensor.rand(
+            *sizes, bits=encoder._precision_bits, device=device
+        )
         rand._tensor.encoder = encoder
         rand.ptype = Ptype.binary
         return rand.to(Ptype.arithmetic, bits=encoder._precision_bits)
@@ -377,10 +379,10 @@ class MPCTensor(CrypTensor):
         generated using the Box-Muller transform with optimizations for
         numerical precision and MPC efficiency.
         """
-        u = MPCTensor.rand(*sizes).flatten()
+        u = MPCTensor.rand(*sizes, device=device).flatten()
         odd_numel = u.numel() % 2 == 1
         if odd_numel:
-            u = MPCTensor.cat([u, MPCTensor.rand((1,))])
+            u = MPCTensor.cat([u, MPCTensor.rand((1,), device=device)])
 
         n = u.numel() // 2
         u1 = u[:n]

--- a/crypten/mpc/primitives/beaver.py
+++ b/crypten/mpc/primitives/beaver.py
@@ -27,6 +27,8 @@ def __beaver_protocol(op, x, y, *args, **kwargs):
         "conv_transpose1d",
         "conv_transpose2d",
     }
+    if x.device != y.device:
+        raise ValueError(f"x lives on device {x.device} but y on device {y.device}")
 
     provider = crypten.mpc.get_default_provider()
     a, b, c = provider.generate_additive_triple(


### PR DESCRIPTION
Summary:
This diff fixes two issues:

- Some of the communication primitives in `DistributedCommunicator` try to communicate `tensor` rather than `tensor.data`. This works correctly when the `tensor` is a regular PyTorch tensor (that is, when it lives on CPU) but not when it is a `CUDALongTensor` (that is, when it lives on GPU).
- The `MPCTensor.rand{n}` functions ignore the `device` input argument.

Differential Revision: D24843334

