### PR TITLE
Quick fix reshape autograd

### DIFF
--- a/crypten/gradients.py
+++ b/crypten/gradients.py
@@ -218,9 +218,9 @@ class AutogradView(AutogradFunction):
 @register_function("reshape")
 class AutogradReshape(AutogradFunction):
     @staticmethod
-    def forward(ctx, input, shape):
+    def forward(ctx, input, *shape):
         ctx.save_for_backward(input.size())
-        return input.reshape(shape)
+        return input.reshape(*shape)
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/tutorials/Tutorial_1_Basics_of_CrypTen_Tensors.ipynb
+++ b/tutorials/Tutorial_1_Basics_of_CrypTen_Tensors.ipynb
@@ -8,21 +8,21 @@
    "source": [
     "# Tutorial 1: Basics of CrypTen Tensors\n",
     "\n",
-    "We now have a high-level understanding of how secure MPC works. Through these tutorials, we will explain how to use CrypTen to carry out secure operations on encrypted tensors. In this tutorial, we will introduce a fundamental building block in CrypTen, called a ```CrypTensor```.  ```CrypTensor```s are encrypted ```torch``` tensors that can be used for computing securely on data. \n",
+    "We now have a high-level understanding of how secure MPC works. Through these tutorials, we will explain how to use CrypTen to carry out secure operations on encrypted tensors. In this tutorial, we will introduce a fundamental building block in CrypTen, called a ```CrypTensor```.  ```CrypTensors``` are encrypted ```torch``` tensors that can be used for computing securely on data. \n",
     "\n",
-    "CrypTen currently only supports secure MPC protocols (though we intend to add support for other advanced encryption protocols). Using the ```mpc``` backend, ```CrypTensor```s act as ```torch``` tensors whose values are encrypted using secure MPC protocols. Tensors created using the ```mpc``` backend are called ```MPCTensor```s. We will go into greater detail about ```MPCTensors``` in Tutorial 2. \n",
+    "CrypTen currently only supports secure MPC protocols (though we intend to add support for other advanced encryption protocols). Using the ```mpc``` backend, ```CrypTensors``` act as ```torch``` tensors whose values are encrypted using secure MPC protocols. Tensors created using the ```mpc``` backend are called ```MPCTensors```. We will go into greater detail about ```MPCTensors``` in Tutorial 2. \n",
     "\n",
     "Let's begin by importing ```crypten``` and ```torch``` libraries. (If the imports fail, please see the installation instructions in the README.)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import torch\n",
     "import crypten\n",
+    "import torch\n",
     "\n",
     "crypten.init()"
    ]
@@ -34,12 +34,12 @@
     "### Creating Encrypted Tensors\n",
     "CrypTen provides a ```crypten.cryptensor``` factory function, similar to ```torch.tensor```, to make creating ```CrypTensors``` easy. \n",
     "\n",
-    "Let's begin by creating a ```torch``` tensor and encrypting it using ```crypten.cryptensor```. To decrypt a ```CrypTensor```, use ```get_plain_text()``` to return the original tensor.  (```CrypTensor```s can also be created directly from a list or an array.)\n"
+    "Let's begin by creating a ```torch``` tensor and encrypting it using ```crypten.cryptensor```. To decrypt a ```CrypTensor```, use ```get_plain_text()``` to return the original tensor.  (```CrypTensors``` can also be created directly from a list or an array.)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -255,16 +255,17 @@
       "Private reciprocal: tensor([10.0009,  3.3335,  2.0000,  1.0000,  0.6667,  0.5000,  0.4000])\n",
       "\n",
       "Public  logarithm: tensor([-2.3026, -1.2040, -0.6931,  0.0000,  0.4055,  0.6931,  0.9163])\n",
-      "Private logarithm: tensor([-2.3181, -1.2110, -0.6997,  0.0004,  0.4038,  0.6918,  0.9150])\n",
+      "Private logarithm: tensor([    -2.3181,     -1.2110,     -0.6997,      0.0004,      0.4038,\n",
+      "             0.6918,      0.9150])\n",
       "\n",
       "Public  exponential: tensor([ 1.1052,  1.3499,  1.6487,  2.7183,  4.4817,  7.3891, 12.1825])\n",
       "Private exponential: tensor([ 1.1021,  1.3440,  1.6468,  2.7121,  4.4574,  7.3280, 12.0188])\n",
       "\n",
       "Public  square root: tensor([0.3162, 0.5477, 0.7071, 1.0000, 1.2247, 1.4142, 1.5811])\n",
-      "Private square root: tensor([0.3135, 0.5445, 0.7051, 1.0000, 1.2195, 1.4080, 1.5762])\n",
+      "Private square root: tensor([0.3147, 0.5477, 0.7071, 0.9989, 1.2237, 1.4141, 1.5811])\n",
       "\n",
       "Public  tanh: tensor([0.0997, 0.2913, 0.4621, 0.7616, 0.9051, 0.9640, 0.9866])\n",
-      "Private tanh: tensor([0.1019, 0.2892, 0.4613, 0.7642, 0.9081, 0.9689, 0.9922])\n"
+      "Private tanh: tensor([0.0994, 0.2914, 0.4636, 0.7636, 0.9069, 0.9652, 0.9873])\n"
      ]
     }
    ],
@@ -321,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -372,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -412,7 +413,7 @@
     "\n",
     "# Reshaping\n",
     "w_enc = z_enc.reshape(-1, 6)\n",
-    "print('\\nReshaping:\\n', w_enc.get_plain_text())\n"
+    "print('\\nReshaping:\\n', w_enc.get_plain_text())"
    ]
   },
   {
@@ -422,7 +423,7 @@
     "\n",
     "### Implementation Note\n",
     "\n",
-    "Due to internal implementation details, ```CrypTensors``` must be the first operand of operations that combine ```CrypTensor```s and ```torch``` tensors. That is, for a ```CrypTensor``` ```x_enc``` and a plaintext tensor ```y```:\n",
+    "Due to internal implementation details, ```CrypTensors``` must be the first operand of operations that combine ```CrypTensors``` and ```torch``` tensors. That is, for a ```CrypTensor``` ```x_enc``` and a plaintext tensor ```y```:\n",
     "- The expression ```x_enc < y``` is valid, but the equivalent expression ```y > x_enc``` will result in an error.\n",
     "- The expression ```x_enc + y``` is valid, but the equivalent expression ```y + x_enc``` will result in an error.\n",
     "\n",
@@ -446,7 +447,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

In [Tutorial_1_Basics_of_CrypTen_Tensors.ipynb](https://github.com/facebookresearch/CrypTen/blob/master/tutorials/Tutorial_1_Basics_of_CrypTen_Tensors.ipynb) is is used ```reshape```, but the call fails because the ```AutogradReshape forward``` method does not expect that many arguments.

This is a simple change such that the ```shape``` argument is treated as a variable number of arguments.

## How Has This Been Tested (if it applies)

Run the tutorial and it worked

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
