### PR TITLE
Fix decode

### DIFF
--- a/crypten/encoder.py
+++ b/crypten/encoder.py
@@ -64,7 +64,7 @@ class FixedPointEncoder:
         assert is_int_tensor(tensor), "input must be a LongTensor"
         if self._scale > 1:
             correction = (tensor < 0).long()
-            dividend = tensor / self._scale - correction
+            dividend = tensor // self._scale - correction
             remainder = tensor % self._scale
             remainder += (remainder == 0).long() * self._scale * correction
 


### PR DESCRIPTION
## Types of changes

Use ```true_div``` when decoding a value - this would give "bad" values when decoding float encoded numbers.
Ex: ```fp.encode(4.6)``` --> ```301465``` --> ```fp.decode(301465)``` --> ```4```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue
Correct decoding of float encoded values

## How Has This Been Tested (if it applies)
 - Changed the tests to take into consideration float values

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
