### PR TITLE
Fix onnx_converter for tutorial 5 models

### DIFF
--- a/crypten/__init__.py
+++ b/crypten/__init__.py
@@ -400,6 +400,9 @@ def cat(tensors, dim=0):
     Concatenates the specified CrypTen `tensors` along dimension `dim`.
     """
     assert isinstance(tensors, list), "input to cat must be a list"
+    if all(torch.is_tensor(t) for t in tensors):
+        return torch.cat(tensors)
+
     assert all(isinstance(t, CrypTensor) for t in tensors), "inputs must be CrypTensors"
     tensor_types = [get_cryptensor_type(t) for t in tensors]
     assert all(

--- a/crypten/mpc/primitives/arithmetic.py
+++ b/crypten/mpc/primitives/arithmetic.py
@@ -601,7 +601,7 @@ class ArithmeticSharedTensor(object):
         """
         result = self.shallow_copy()
         index = index.long()
-        if dimension is None:
+        if dimension is None or self.dim() == 0:
             result.share = torch.take(self.share, index)
         else:
             all_indices = [slice(0, x) for x in self.size()]


### PR DESCRIPTION
Summary:
Deals with failures in Tutorial 5 brought to our attention by gmuraru. This should also fix the following issue: https://github.com/facebookresearch/CrypTen/issues/187

- Fixed parameter names for Conv inputs to be "weight", "bias"
- Fixed Constant folding for Gather modules
- Fixed Constant outputs for certain situations where graph would erroneously create encrypted indices
- Fixed inputs for Reshape in these cases
- Added tests to ensure tutorial 5 modules will continue to work

Differential Revision: D25817024

