### PR TITLE
Remove notebook dependency

### DIFF
--- a/pycon-workshop-2020/requirements.txt
+++ b/pycon-workshop-2020/requirements.txt
@@ -35,7 +35,6 @@ matplotlib==3.2.1
 mistune==0.8.4
 nbconvert==5.6.1
 nbformat==5.0.5
-notebook==6.0.3
 numpy==1.18.2
 oauthlib==3.1.0
 onnx==1.6.0


### PR DESCRIPTION
Summary: Removed notebook dependency from pycon-workshop-2020/requirements.txt for security reasons

Differential Revision: D25961226

