### PR TITLE
Update tfe_benchmarks to fix CircleCI

### DIFF
--- a/examples/tfe_benchmarks/tfe_benchmarks.py
+++ b/examples/tfe_benchmarks/tfe_benchmarks.py
@@ -359,7 +359,7 @@ def accuracy(output, target, topk=(1,)):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].flatten().float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 


### PR DESCRIPTION
Summary:
tfe_benchmarks was failing in CircleCI due to `view(-1)` no longer working.

See [CircleCI failure](https://app.circleci.com/pipelines/github/facebookresearch/CrypTen/808/workflows/a87d4223-0035-4ea3-89c9-c050c4d1fd30/jobs/2952)

Differential Revision: D26515355

