### PR TITLE
Update onnx_converter for new Linear jit

### DIFF
--- a/crypten/gradients.py
+++ b/crypten/gradients.py
@@ -151,6 +151,20 @@ class AutogradTranspose(AutogradFunction):
         return grad_output.transpose(dim2, dim1)
 
 
+@register_function("permute")
+class AutogradPermute(AutogradFunction):
+    @staticmethod
+    def forward(ctx, input, dims):
+        ctx.save_for_backward(dims)
+        return input.permute(dims)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (dims,) = ctx.saved_tensors
+        inds = [dims.index(x) for x in range(len(dims))]
+        return grad_output.permute(inds)
+
+
 @register_function("flip")
 class AutogradFlip(AutogradFunction):
     @staticmethod

--- a/crypten/nn/onnx_converter.py
+++ b/crypten/nn/onnx_converter.py
@@ -161,9 +161,7 @@ class FromOnnx:
     def to_crypten(self):
         """Constructs a CrypTen model from the onnx graph"""
         input_names, output_names = self._get_input_output_names()
-
         crypten_model = module.Graph(input_names[0], output_names[0])
-        import crypten
 
         constant_module = None
         for node in self.onnx_model.graph.node:

--- a/test/test_gradients.py
+++ b/test/test_gradients.py
@@ -424,6 +424,14 @@ class TestGradients:
                 for dim1 in range(tensor.dim()):
                     self._check_forward_backward("transpose", tensor, dim0, dim1)
 
+    def test_permute(self):
+        for ndims in range(5):
+            size = tuple([3] * ndims)
+            tensor = get_random_test_tensor(size=size, is_float=True)
+
+            for perm in itertools.permutations(list(range(ndims))):
+                self._check_forward_backward("permute", tensor, perm)
+
     def test_conv1d_smaller_signal_one_channel(self):
         self._conv1d(5, 1)
 


### PR DESCRIPTION
Summary:
PyTorch landed a diff recently (D26320711) that changed how `torch.nn.modules.Linear` is traced when exporting to onnx. The new behavior generates the following graph:

```
'3': Transpose
   input: []
   parameters: ['weight']
'4': Matmul
   input: ['input', '3']
   parameters: []
'5': Add
    input: ['4']
    parameters: ['bias']
```

This caused failures in 6 unit tests in `test_onnx_converter` and 4 failures in `test_nn`

To enable this graph, this diff does the following:

- Handles possible parameter input in Transpose.from_onnx()
- Adds `AutogradPermute` so `Transpose` module does not detach from the autograd tape
- Adds test coverage for `permute` gradient

Differential Revision: D26640057

