### PR TITLE
Update binary comparator for arithmetic rshift

### DIFF
--- a/test/test_binary.py
+++ b/test/test_binary.py
@@ -246,7 +246,6 @@ class TestBinary(MultiProcessTestCase):
             encrypted_out = encrypted_tensor + encrypted_tensor2
             self._check(encrypted_out, reference, "%s add failed" % tensor_type)
 
-    @unittest.skip("omitting since disabled in fbcode")
     def test_comparators(self):
         """Test comparators (>, >=, <, <=, ==, !=)"""
         for _scale in [False, True]:


### PR DESCRIPTION
Summary:
PyTorch recently updated the rshift operand (`>>`) to follow clang conventions (logical shift on unsigned types, arithmetic shift on signed types). I believe this was done in [#51749](https://github.com/pytorch/pytorch/pull/51749)

Because PyTorch does not support signed 64-bit types, this means we are stuck with arithmetic shift.

By chance, our adder circuit does not use bit shifts (and instead uses multiplication to implement the wiring).

However, binary comparator circuits all used `__rshift__()` operands. This diff modifies these circuits to operate under the arithmetic shift assumptions.

Differential Revision: D26673360

