### PR TITLE
Enforce calls to `torch.tensor()` constructor following deprecation

### DIFF
--- a/crypten/__init__.py
+++ b/crypten/__init__.py
@@ -212,7 +212,7 @@ def _setup_przs(device=None):
 
     numpy.random.seed(seed=None)
     next_seed = torch.tensor(numpy.random.randint(-(2 ** 63), 2 ** 63 - 1, (1,)))
-    prev_seed = torch.LongTensor([0])  # placeholder
+    prev_seed = torch.tensor([0], dtype=torch.long)  # placeholder
 
     # Send random seed to next party, receive random seed from prev party
     world_size = comm.get().get_world_size()

--- a/crypten/mpc/primitives/circuit.py
+++ b/crypten/mpc/primitives/circuit.py
@@ -15,7 +15,7 @@ import torch
 # [1] -> 001000100010....0010  =                     0010 x 16
 # [2] -> 000010000000....0010  =                 00001000 x  8
 # [n] -> [2^n 0s, 1, (2^n -1) 0s] x (32 / (2^n))
-__MASKS = torch.LongTensor(
+__MASKS = torch.tensor(
     [
         6148914691236517205,
         2459565876494606882,
@@ -23,7 +23,8 @@ __MASKS = torch.LongTensor(
         36029346783166592,
         140737488388096,
         2147483648,
-    ]
+    ],
+    dtype=torch.long,
 )
 
 # Cache other masks and constants to skip computation during each call

--- a/examples/bandits/launcher.py
+++ b/examples/bandits/launcher.py
@@ -283,7 +283,7 @@ def get_monitor_func(args, buffers, visualizer, window, title, progress_iter):
             if args.visualize:
                 window[0] = learning_curve(
                     visualizer,
-                    torch.LongTensor(buffers["idx"]),
+                    torch.tensor(buffers["idx"], dtype=torch.long),
                     torch.DoubleTensor(buffers["cumulative_reward"]),
                     window=window[0],
                     title=title,

--- a/examples/bandits/private_contextual_bandits.py
+++ b/examples/bandits/private_contextual_bandits.py
@@ -152,7 +152,7 @@ def epsilon_greedy(
 
     # define scoring function
     def score_func(scores, A_inv, b, context):
-        explore = crypten.bernoulli(torch.Tensor([epsilon]))
+        explore = crypten.bernoulli(torch.tensor([epsilon]))
         rand_scores = crypten.rand(*scores.size())
         scores.mul_(1 - explore).add_(rand_scores.mul(explore))
 

--- a/examples/mpc_imagenet/mpc_imagenet.py
+++ b/examples/mpc_imagenet/mpc_imagenet.py
@@ -82,7 +82,7 @@ def run_experiment(
         image, target = sample
         image = transform(image)
         image.unsqueeze_(0)
-        target = torch.LongTensor([target])
+        target = torch.tensor([target], dtype=torch.long)
 
         # perform inference using encrypted model on encrypted sample:
         encrypted_image = crypten.cryptensor(image)

--- a/test/test_arithmetic.py
+++ b/test/test_arithmetic.py
@@ -414,7 +414,7 @@ class TestArithmetic(MultiProcessTestCase):
 
             # Check that the encrypted_out and encrypted point to the same
             # thing.
-            encrypted_out[0:2] = torch.FloatTensor([0, 1])
+            encrypted_out[0:2] = torch.tensor([0.0, 1.0], dtype=torch.float)
             ref = encrypted.squeeze().get_plain_text()
             self._check(encrypted_out, ref, "squeeze failed")
 

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -16,7 +16,7 @@ from crypten.encoder import FixedPointEncoder, nearest_integer_division
 
 def get_test_tensor(max_value=10, float=False):
     """Create simple test tensor."""
-    tensor = torch.LongTensor(list(range(max_value)))
+    tensor = torch.tensor(list(range(max_value)), dtype=torch.long)
     if float:
         tensor = tensor.float()
     return tensor
@@ -70,11 +70,11 @@ class TestCommon(unittest.TestCase):
         # test without scaling:
         scale = 1
         reference = [[-26, -25, -7, -5, -4, -1, 0, 1, 3, 4, 5, 7, 25, 26]]
-        tensor = torch.LongTensor(reference)
+        tensor = torch.tensor(reference, dtype=torch.long)
         result = nearest_integer_division(tensor, scale)
         self._check(
-            torch.LongTensor(result.tolist()),
-            torch.LongTensor(reference),
+            torch.tensor(result.tolist(), dtype=torch.long),
+            torch.tensor(reference, dtype=torch.long),
             "Nearest integer division failed.",
         )
 
@@ -83,8 +83,8 @@ class TestCommon(unittest.TestCase):
         reference = [[-6, -6, -2, -1, -1, 0, 0, 0, 1, 1, 1, 2, 6, 6]]
         result = nearest_integer_division(tensor, scale)
         self._check(
-            torch.LongTensor(result.tolist()),
-            torch.LongTensor(reference),
+            torch.tensor(result.tolist(), dtype=torch.long),
+            torch.tensor(reference, dtype=torch.long),
             "Nearest integer division failed.",
         )
 

--- a/test/test_communicator.py
+++ b/test/test_communicator.py
@@ -63,7 +63,7 @@ class TestCommunicator:
         self.assertEqual(this_generator, generator0)
 
     def test_send_recv(self):
-        tensor = torch.LongTensor([self.rank])
+        tensor = torch.tensor([self.rank], dtype=torch.long)
 
         # Send forward, receive backward
         dst = (self.rank + 1) % self.world_size
@@ -160,7 +160,7 @@ class TestCommunicator:
 
     def test_broadcast(self):
         for rank in range(self.world_size):
-            tensor = torch.LongTensor([0])
+            tensor = torch.tenosr([0], dtype=torch.long)
             if self.rank == rank:
                 tensor += 1
 

--- a/test/test_crypten.py
+++ b/test/test_crypten.py
@@ -83,9 +83,9 @@ class TestCrypten(MultiProcessTestCase):
         randvec = crypten.rand(int(1e6)).get_plain_text()
         mean = torch.mean(randvec)
         var = torch.var(randvec)
-        self.assertTrue(torch.isclose(mean, torch.Tensor([0.5]), rtol=1e-3, atol=1e-3))
+        self.assertTrue(torch.isclose(mean, torch.tensor([0.5]), rtol=1e-3, atol=1e-3))
         self.assertTrue(
-            torch.isclose(var, torch.Tensor([1.0 / 12]), rtol=1e-3, atol=1e-3)
+            torch.isclose(var, torch.tensor([1.0 / 12]), rtol=1e-3, atol=1e-3)
         )
 
     def test_bernoulli(self):

--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -2080,7 +2080,7 @@ class TestMPC(object):
 
         # Check the expected number of zero elements
         # For speed, restrict test to single p = 0.4
-        encr_tensor = MPCTensor(torch.Tensor(int(1e5), 2, 2).fill_(1).to(self.device))
+        encr_tensor = MPCTensor(torch.empty((int(1e5), 2, 2)).fill_(1).to(self.device))
         dropout_encr_tensor = encr_tensor.dropout(0.4)
         dropout_tensor = dropout_encr_tensor.get_plain_text()
         frac_zero = float((dropout_tensor == 0).sum()) / dropout_tensor.nelement()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -126,7 +126,7 @@ class TestNN(object):
         Tests the global average pool module with fixed 4-d test tensors
         """
         # construct basic input
-        base_tensor = torch.Tensor([[2, 1], [3, 0]])
+        base_tensor = torch.tensor([[2, 1], [3, 0]])
         all_init = []
         for i in range(-2, 3):
             all_init.append(torch.add(base_tensor, i))


### PR DESCRIPTION
Summary: Recent PyTorch PR deprecates the use of `torch.Tensor`, `torch.LongTensor`, and `torch.FloatTensor` as constructors, in favor of `torch.tensor()`. This diff replaces all instances of these constructors throughout CrypTen's codebase.

Differential Revision: D27481601

