### PR TITLE
Update ONNX exporter to opset version 11

### DIFF
--- a/crypten/nn/onnx_converter.py
+++ b/crypten/nn/onnx_converter.py
@@ -15,6 +15,7 @@ import torch.onnx.symbolic_helper as sym_help
 import torch.onnx.symbolic_registry as sym_registry
 import torch.onnx.utils
 from onnx import numpy_helper
+from torch.onnx import OperatorExportTypes
 
 from . import module
 
@@ -60,12 +61,14 @@ def _from_pytorch_to_bytes(pytorch_model, dummy_input):
 
 
 def _export_pytorch_model(f, pytorch_model, dummy_input):
-    """Returns a Binary I/O stream containing exported model"""
+    """Returns a Binary I/O stream containing exported model."""
     kwargs = {
         "do_constant_folding": False,
         "export_params": True,
-        "enable_onnx_checker": False,
+        "enable_onnx_checker": True,
         "input_names": ["input"],
+        "operator_export_type": OperatorExportTypes.ONNX,
+        "opset_version": 11,
         "output_names": ["output"],
     }
     try:

--- a/crypten/nn/tensorboard.py
+++ b/crypten/nn/tensorboard.py
@@ -24,19 +24,20 @@ def graph(model):
         model = graph
 
     # create mapping to more interpretable node naming:
-    mapping = {model.input_name: model.input_name}
+    mapping = {input_name: input_name for input_name in model.input_names}
     modules = {name: module for name, module in model.named_modules()}
     for name, module in modules.items():
         op = str(type(module))[26:-2]
         mapping[name] = "%s_%s" % (op, name)
 
-    # create input variable:
+    # create input variables:
     nodes = [
         NodeDef(
-            name=mapping[model.input_name].encode(encoding="utf_8"),
+            name=mapping[input_name].encode(encoding="utf_8"),
             op="Variable",
             input=[],
         )
+        for input_name in model.input_names
     ]
 
     # loop all graph connections:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -342,6 +342,12 @@ class TestNN(object):
                 else:
                     encr_inputs.append(inputs[-1])
 
+            # gather module cannot work with encrypted indices as input:
+            if module_name in ["Gather"]:
+                with self.assertRaises(ValueError):
+                    encr_output = encr_module(encr_inputs)
+                continue
+
             # compare model outputs:
             reference = module_lambdas[module_name](inputs)
             encr_output = encr_module(encr_inputs)
@@ -1039,6 +1045,12 @@ class TestNN(object):
             linear.zero_grad()
             if not linear.encrypted and not torch.is_tensor(_sample):
                 with self.assertRaises(RuntimeError):
+                    output = linear(_sample)
+                return
+
+            # when model is encrypted, feeding unencrypted input is not supported:
+            if linear.encrypted and torch.is_tensor(_sample):
+                with self.assertRaises(NotImplementedError):
                     output = linear(_sample)
                 return
 

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -13,7 +13,7 @@ import crypten.nn.tensorboard as tensorboard
 
 
 class TestTensorboard(MultiProcessTestCase):
-    """This class tests the crypten.nn.tensorboad package."""
+    """This class tests the crypten.nn.tensorboard package."""
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Summary: This updates the opset version of ONNX used to 11. Version 11 has some changes with respect to the `Gather` operation that are useful in tracing embedding(bag) modules. It also changes the input of some other modules (moving attributes to inputs).

Differential Revision: D27475189

