### PR TITLE
Import parameters from ONNX graph in separate module

### DIFF
--- a/crypten/gradients.py
+++ b/crypten/gradients.py
@@ -1459,6 +1459,12 @@ class AutogradMaxPool2D(AutogradFunction):
 class AutogradConv1D(AutogradFunction):
     @staticmethod
     def forward(ctx, input, kernel, padding=0, stride=1, dilation=1, groups=1):
+        if isinstance(stride, (int, float)):
+            stride = (stride,)
+        if isinstance(padding, (int, float)):
+            padding = (padding,)
+        if isinstance(dilation, (int, float)):
+            dilation = (dilation,)
         ctx.save_multiple_for_backward(
             (input, kernel, padding, stride, dilation, groups)
         )
@@ -1491,10 +1497,10 @@ class AutogradConv1D(AutogradFunction):
         output_padding = torch.nn.grad._grad_input_padding(
             grad_output,
             input.size(),
-            (stride,),
-            (padding,),
+            stride,
+            padding,
             (kernel_size,),
-            dilation=(dilation,),
+            dilation=dilation,
         )
         grad_input = grad_output.conv_transpose1d(
             kernel,

--- a/crypten/nn/__init__.py
+++ b/crypten/nn/__init__.py
@@ -23,6 +23,7 @@ from .module import (
     ConstantPad1d,
     ConstantPad2d,
     ConstantPad3d,
+    Conv,
     Conv1d,
     Conv2d,
     Div,
@@ -36,6 +37,7 @@ from .module import (
     Expand,
     Flatten,
     Gather,
+    Gemm,
     GlobalAveragePool,
     Graph,
     GroupNorm,
@@ -48,6 +50,7 @@ from .module import (
     Module,
     ModuleDict,
     Mul,
+    Parameter,
     Pow,
     Range,
     ReLU,
@@ -66,7 +69,7 @@ from .module import (
     Unsqueeze,
     Where,
 )
-from .onnx_converter import TF_AND_TF2ONNX, from_pytorch, from_tensorflow
+from .onnx_converter import TF_AND_TF2ONNX, from_pytorch, from_onnx
 
 
 # expose contents of package
@@ -87,6 +90,7 @@ __all__ = [
     "ConstantPad1d",
     "ConstantPad2d",
     "ConstantPad3d",
+    "Conv",
     "Conv1d",
     "Conv2d",
     "CrossEntropyLoss",
@@ -101,8 +105,9 @@ __all__ = [
     "Expand",
     "Flatten",
     "from_pytorch",
-    "from_tensorflow",
+    "from_onnx",
     "Gather",
+    "Gemm",
     "GlobalAveragePool",
     "Graph",
     "GroupNorm",
@@ -117,6 +122,7 @@ __all__ = [
     "ModuleDict",
     "MSELoss",
     "Mul",
+    "Parameter",
     "Pow",
     "Range",
     "ReLU",

--- a/crypten/nn/loss.py
+++ b/crypten/nn/loss.py
@@ -141,6 +141,8 @@ class CrossEntropyLoss(_Loss):
     """  # noqa: W605
 
     def forward(self, x, y):
+        x = x.squeeze()
+        y = y.squeeze()
         assert x.size() == y.size(), "input and target must have the same size"
         return x.cross_entropy(y, skip_forward=self.skip_forward)
 

--- a/test/test_onnx_converter.py
+++ b/test/test_onnx_converter.py
@@ -316,7 +316,7 @@ class TestOnnxConverter(object):
         op_types = ["Sum", "AveragePool", "Mean"]
         for op_type in op_types:
             node = Node(op_type)
-            operator = onnx_converter.FromOnnx._get_operator_class(node.op_type, {})
+            operator = onnx_converter._get_operator_class(node.op_type, {})
             self.assertTrue(
                 issubclass(operator, crypten.nn.Module),
                 f"{op_type} operator class {operator} is not a CrypTen module.",
@@ -326,18 +326,14 @@ class TestOnnxConverter(object):
         node = Node("Conv")
         for kernel_shape in kernel_shapes:
             attributes = {"kernel_shape": kernel_shape}
-            operator = onnx_converter.FromOnnx._get_operator_class(
-                node.op_type, attributes
-            )
+            operator = onnx_converter._get_operator_class(node.op_type, attributes)
 
         # check invalid op_types
-        invalid_types = [("Conv", {"kernel_shape": [3, 3, 3]}), ("Banana", {})]
+        invalid_types = [("Convolution", {"kernel_shape": [3, 3, 3]}), ("Banana", {})]
         for invalid_type, attr in invalid_types:
             with self.assertRaises(ValueError):
                 node = Node(invalid_type)
-                operator = onnx_converter.FromOnnx._get_operator_class(
-                    node.op_type, attr
-                )
+                operator = onnx_converter._get_operator_class(node.op_type, attr)
 
     def test_export_pytorch_model(self):
         """Tests loading of onnx model from a file"""


### PR DESCRIPTION
Summary:
The ONNX convertor currently treats parameters separately: it gathers them and uses them to initialize stateful modules. This works fine for modules like `Linear` or `Conv2d`, but it breaks as soon as we are trying to convert a module that has "custom" parameters: these parameters are simply forgotten by the current convertor.

This diff introduces a `crypten.nn.Parameter` module that is its own node in the computation graph. These parameters are fed as input into other modules (akin to how ONNX specifies the graph). This makes other modules essentially stateless. The diff adds missing stateless modules for convolution, etc. It does maintain our prior stateful modules like `nn.Linear` for backwards compatibility (but these are no longer created by the ONNX convertor).

The diff also changes `crypten.nn.Graph` to support multiple outputs. This is necessary because some ONNX specifications produce multiple outputs (for example, the batch normalization specification).

Now that all modules are stateless, in a follow-up diff, we could do away with many modules altogether and make `crypten.nn.Graph` a computation graph of `AutogradFunction`s.

Differential Revision: D27847404

