### PR TITLE
Fix crypten.log

### DIFF
--- a/crypten/__init__.py
+++ b/crypten/__init__.py
@@ -547,7 +547,7 @@ def log(*args, in_order=False, dst=0, **kwargs):
             multiple ranks to log from.
     """
     __multiprocess_print_helper(
-        logging.log, *args, in_order=in_order, dst=dst, **kwargs
+        logging.info, *args, in_order=in_order, dst=dst, **kwargs
     )
 
 

--- a/crypten/__init__.py
+++ b/crypten/__init__.py
@@ -31,6 +31,14 @@ no_grad = CrypTensor.no_grad
 enable_grad = CrypTensor.enable_grad
 set_grad_enabled = CrypTensor.set_grad_enabled
 
+# Setup RNG generators
+generators = {
+    "prev": {},
+    "next": {},
+    "local": {},
+    "global": {},
+}
+
 
 def init(party_name=None, device=None):
     """
@@ -61,7 +69,7 @@ def init(party_name=None, device=None):
 
     # Setup seeds for Random Number Generation
     if comm.get().get_rank() < comm.get().get_world_size():
-        _setup_prng(device=device)
+        _setup_prng()
         if crypten.mpc.ttp_required():
             crypten.mpc.provider.ttp_provider.TTPClient._init()
 
@@ -175,10 +183,16 @@ def is_encrypted_tensor(obj):
     return isinstance(obj, CrypTensor)
 
 
-def _setup_prng(device=None):
+def _setup_prng():
     """
     Generate shared random seeds to generate pseudo-random sharings of
-    zero. The random seeds are shared such that each process shares
+    zero. For each device, we generator four random seeds:
+        "prev"  - shared seed with the previous party
+        "next"  - shared seed with the next party
+        "local" - seed known only to the local party (separate from torch's default seed to prevent interference from torch.manual_seed)
+        "gloabl"- seed shared by all parties
+
+    The "prev" and "next" random seeds are shared such that each process shares
     one seed with the previous rank process and one with the next rank.
     This allows for the generation of `n` random values, each known to
     exactly two of the `n` parties.
@@ -188,63 +202,62 @@ def _setup_prng(device=None):
     pseudo-random sharing of zero. (This can be done for binary
     sharing using bitwise-xor rather than addition / subtraction)
     """
-    # Initialize RNG Generators
-    comm.get().g0 = torch.Generator()
-    comm.get().g1 = torch.Generator()
+    global generators
 
-    device = "cuda" if device is None else device
-    device = torch.device(device)
-    assert device.type == "cuda", "Must be a GPU device"
+    # Initialize RNG Generators
+    for key in generators.keys():
+        generators[key][torch.device("cpu")] = torch.Generator()
 
     if torch.cuda.is_available():
-        comm.get().g0_cuda = torch.Generator(device=device)
-        comm.get().g1_cuda = torch.Generator(device=device)
+        cuda_device_names = ["cuda"]
+        for i in range(torch.cuda.device_count()):
+            cuda_device_names.append(f"cuda:{i}")
+        cuda_devices = [torch.device(name) for name in cuda_device_names]
+
+        for device in cuda_devices:
+            for key in generators.keys():
+                generators[key][device] = torch.Generator(device=device)
 
     # Generate random seeds for Generators
     # NOTE: Chosen seed can be any number, but we choose as a random 64-bit
-    # integer here so other parties cannot guess its value.
+    # integer here so other parties cannot guess its value. We use os.urandom(8)
+    # here to generate seeds so that forked processes do not generate the same seed.
 
-    # We sometimes get here from a forked process, which causes all parties
-    # to have the same RNG state. Reset the seed to make sure RNG streams
-    # are different in all the parties. We use numpy's random here since
-    # setting its seed to None will produce different seeds even from
-    # forked processes.
+    for device in generators["prev"].keys():
+        # Generate next / prev seeds.
+        seed = int.from_bytes(os.urandom(8), "big") - 2 ** 63
+        next_seed = torch.tensor(seed)
+        prev_seed = torch.tensor([0], dtype=torch.long)  # populated by irecv
 
-    seed = int.from_bytes(os.urandom(8), "big") - 2 ** 63
-    next_seed = torch.tensor(seed)
-    prev_seed = torch.tensor([0], dtype=torch.long)  # placeholder
+        # Send random seed to next party, receive random seed from prev party
+        world_size = comm.get().get_world_size()
+        rank = comm.get().get_rank()
+        if world_size >= 2:  # Guard against segfaults when world_size == 1.
+            next_rank = (rank + 1) % world_size
+            prev_rank = (next_rank - 2) % world_size
 
-    # Send random seed to next party, receive random seed from prev party
-    world_size = comm.get().get_world_size()
-    rank = comm.get().get_rank()
-    if world_size >= 2:  # Otherwise sending seeds will segfault.
-        next_rank = (rank + 1) % world_size
-        prev_rank = (next_rank - 2) % world_size
+            req0 = comm.get().isend(tensor=next_seed, dst=next_rank)
+            req1 = comm.get().irecv(tensor=prev_seed, src=prev_rank)
 
-        req0 = comm.get().isend(tensor=next_seed, dst=next_rank)
-        req1 = comm.get().irecv(tensor=prev_seed, src=prev_rank)
+            req0.wait()
+            req1.wait()
+        else:
+            prev_seed = next_seed
 
-        req0.wait()
-        req1.wait()
-    else:
-        prev_seed = next_seed
+        # Pair-wise shared generators - Each party shares one generator (prev)
+        # with previous party and one (next) with next party
+        generators["prev"][device].manual_seed(next_seed.item())
+        generators["next"][device].manual_seed(prev_seed.item())
 
-    # Pair-wise shared generators - Each party shares one generator (g0)
-    # with previous party and one (g1) with next party
-    comm.get().g0.manual_seed(next_seed.item())
-    comm.get().g1.manual_seed(prev_seed.item())
+        # Create local generator - Each party has a separate local generator
+        local_seed = int.from_bytes(os.urandom(8), "big") - 2 ** 63
+        generators["local"][device].manual_seed(local_seed)
 
-    # Create local generator - Each party has a separate local generator
-    local_seed = int.from_bytes(os.urandom(8), "big")
-    comm.get().local_generator = torch.Generator()
-    comm.get().local_generator.manual_seed(local_seed)
-
-    # Create global generator - All parties share one global generator for sync'd rng
-    global_seed = int.from_bytes(os.urandom(8), "big") - 2 ** 63
-    global_seed = torch.tensor(global_seed)
-    global_seed = comm.get().broadcast(global_seed, 0)
-    comm.get().global_generator = torch.Generator()
-    comm.get().global_generator.manual_seed(global_seed.item())
+        # Create global generator - All parties share one global generator for sync'd rng
+        global_seed = int.from_bytes(os.urandom(8), "big") - 2 ** 63
+        global_seed = torch.tensor(global_seed)
+        global_seed = comm.get().broadcast(global_seed, 0)
+        generators["global"][device].manual_seed(global_seed.item())
 
 
 def load_from_party(
@@ -254,7 +267,7 @@ def load_from_party(
     model_class=None,
     src=0,
     load_closure=torch.load,
-    **kwargs
+    **kwargs,
 ):
     """
     Loads an object saved with `torch.save()` or `crypten.save_from_party()`.
@@ -545,6 +558,7 @@ __all__ = [
     "enable_grad",
     "set_grad_enabled",
     "debug",
+    "generators",
     "init",
     "init_thread",
     "log",

--- a/crypten/common/rng.py
+++ b/crypten/common/rng.py
@@ -4,7 +4,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import crypten.communicator as comm
+import crypten
 import torch
 from crypten.cuda import CUDALongTensor
 
@@ -12,7 +12,8 @@ from crypten.cuda import CUDALongTensor
 def generate_random_ring_element(size, ring_size=(2 ** 64), generator=None, **kwargs):
     """Helper function to generate a random number from a signed ring"""
     if generator is None:
-        generator = comm.get().local_generator
+        device = kwargs.get("device", torch.device("cpu"))
+        generator = crypten.generators["local"][device]
     # TODO (brianknott): Check whether this RNG contains the full range we want.
     rand_element = torch.randint(
         -(ring_size // 2),
@@ -29,12 +30,14 @@ def generate_random_ring_element(size, ring_size=(2 ** 64), generator=None, **kw
 
 def generate_kbit_random_tensor(size, bitlength=None, generator=None, **kwargs):
     """Helper function to generate a random k-bit number"""
-    if generator is None:
-        generator = comm.get().local_generator
     if bitlength is None:
         bitlength = torch.iinfo(torch.long).bits
     if bitlength == 64:
         return generate_random_ring_element(size, generator=generator, **kwargs)
+
+    if generator is None:
+        device = kwargs.get("device", torch.device("cpu"))
+        generator = crypten.generators["local"][device]
     rand_tensor = torch.randint(
         0, 2 ** bitlength, size, generator=generator, dtype=torch.long, **kwargs
     )

--- a/crypten/communicator/communicator.py
+++ b/crypten/communicator/communicator.py
@@ -138,33 +138,6 @@ class Communicator:
     def _log_communication_time(self, comm_time):
         self.comm_time += comm_time
 
-    def get_generator(self, idx, device=None):
-        """
-        Get the corresponding RNG generator, as specified by its index and device
-
-        Args:
-            idx: The index of the generator, can be either 0 or 1
-            device: The device that the generator lives in.
-        """
-
-        if device is None:
-            device = torch.device("cpu")
-        else:
-            device = torch.device(device)
-
-        if idx not in {0, 1}:
-            raise RuntimeError(f"Generator idx {idx} out of bounds.")
-
-        generator_name = f"g{idx}_cuda" if device.type == "cuda" else f"g{idx}"
-        generator = getattr(self, generator_name, None)
-
-        if generator is None:
-            raise ValueError(
-                f"Generator {generator_name} is not initialized, call crypten.init() first"
-            )
-
-        return generator
-
 
 def _logging(func):
     """Decorator that performs logging of communication statistics."""

--- a/crypten/cuda/cuda_tensor.py
+++ b/crypten/cuda/cuda_tensor.py
@@ -182,6 +182,14 @@ class CUDALongTensor(object):
 
     @staticmethod
     def __patched_conv_ops(op, x, y, *args, **kwargs):
+
+        if "groups" in kwargs:
+            groups = kwargs["groups"]
+            assert groups == 1, (
+                f"more than one group is unsupported on GPU (groups = {groups})"
+            )
+            del kwargs["groups"]
+
         nb = CUDALongTensor.__N_BLOCKS
         nb2 = nb ** 2
 

--- a/crypten/cuda/cuda_tensor.py
+++ b/crypten/cuda/cuda_tensor.py
@@ -381,7 +381,7 @@ class CUDALongTensor(object):
     def __ifloordiv__(self, y):
         if isinstance(y, CUDALongTensor):
             y = y.tensor()
-        self._tensor //= y
+        self._tensor = torch.div(self._tensor, y, rounding_mode="trunc")
         return self
 
     def __idiv__(self, y):

--- a/crypten/mpc/primitives/arithmetic.py
+++ b/crypten/mpc/primitives/arithmetic.py
@@ -157,13 +157,15 @@ class ArithmeticSharedTensor(object):
         each number being held by exactly 2 parties. One of these parties adds
         this number while the other subtracts this number.
         """
+        from crypten import generators
+
         tensor = ArithmeticSharedTensor(src=SENTINEL)
-        current_share = generate_random_ring_element(
-            *size, generator=comm.get().get_generator(0, device=device), device=device
-        )
-        next_share = generate_random_ring_element(
-            *size, generator=comm.get().get_generator(1, device=device), device=device
-        )
+        if device is None:
+            device = torch.device("cpu")
+        g0 = generators["prev"][device]
+        g1 = generators["next"][device]
+        current_share = generate_random_ring_element(*size, generator=g0, device=device)
+        next_share = generate_random_ring_element(*size, generator=g1, device=device)
         tensor.share = current_share - next_share
         return tensor
 

--- a/crypten/mpc/primitives/binary.py
+++ b/crypten/mpc/primitives/binary.py
@@ -110,13 +110,15 @@ class BinarySharedTensor(object):
         two numbers. A zero sharing is found by having each party xor their two
         numbers together.
         """
+        from crypten import generators
+
         tensor = BinarySharedTensor(src=SENTINEL)
-        current_share = generate_kbit_random_tensor(
-            *size, device=device, generator=comm.get().get_generator(0, device=device)
-        )
-        next_share = generate_kbit_random_tensor(
-            *size, device=device, generator=comm.get().get_generator(1, device=device)
-        )
+        if device is None:
+            device = torch.device("cpu")
+        g0 = generators["prev"][device]
+        g1 = generators["next"][device]
+        current_share = generate_kbit_random_tensor(*size, device=device, generator=g0)
+        next_share = generate_kbit_random_tensor(*size, device=device, generator=g1)
         tensor.share = current_share ^ next_share
         return tensor
 

--- a/crypten/mpc/provider/ttp_provider.py
+++ b/crypten/mpc/provider/ttp_provider.py
@@ -166,6 +166,7 @@ class TTPClient:
             logging.info(f"TTPClient {comm.get().get_rank()} initialized")
 
         def _setup_generators(self):
+            """Setup RNG generator shared between each party (client) and the TTPServer"""
             seed = torch.empty(size=(), dtype=torch.long)
             dist.irecv(
                 tensor=seed, src=comm.get().get_ttp_rank(), group=self.ttp_group

--- a/test/test_communicator.py
+++ b/test/test_communicator.py
@@ -36,32 +36,6 @@ class TestCommunicator:
     This class tests all member functions of crypten package
     """
 
-    def test_przs_generators(self):
-        """Tests that przs generators are initialized independently"""
-        # Check that each party has two unique generators for g0 and g1
-        t0 = torch.randint(-(2 ** 63), 2 ** 63 - 1, (1,), generator=comm.get().g0)
-        t1 = torch.randint(-(2 ** 63), 2 ** 63 - 1, (1,), generator=comm.get().g1)
-        self.assertNotEqual(t0.item(), t1.item())
-
-        # Check that generators are sync'd as expected
-        for rank in range(self.world_size):
-            receiver = rank
-            sender = (rank + 1) % self.world_size
-            if self.rank == receiver:
-                sender_value = comm.get().recv_obj(sender)
-                receiver_value = comm.get().g1.initial_seed()
-                self.assertEqual(sender_value, receiver_value)
-            elif self.rank == sender:
-                sender_value = comm.get().g0.initial_seed()
-                comm.get().send_obj(sender_value, receiver)
-
-    def test_global_generator(self):
-        """Tests that global generator is generated properly"""
-        # Check that all seeds are the same
-        this_generator = comm.get().global_generator.initial_seed()
-        generator0 = comm.get().broadcast_obj(this_generator, src=0)
-        self.assertEqual(this_generator, generator0)
-
     def test_send_recv(self):
         tensor = torch.tensor([self.rank], dtype=torch.long)
 

--- a/test/test_crypten.py
+++ b/test/test_crypten.py
@@ -109,6 +109,10 @@ class TestCrypten(MultiProcessTestCase):
                     )
                     self._check(encrypted_out, reference, "%s failed" % op)
 
+    def test_log(self):
+        """Tests crypten.log logging function."""
+        crypten.log("test")
+
     def test_rand(self):
         """Tests uniform random variable generation on [0, 1)"""
         for size in [(10,), (10, 10), (10, 10, 10)]:


### PR DESCRIPTION
Summary:
We [use `crypten.log` without specifying an explicit logging level](https://fburl.com/diffusion/sd4nxhl4). But [`logging.log` expects a level as first input](https://docs.python.org/3/library/logging.html#logging.Logger.log). As a result, you cannot just call `crypten.log` like we do now -- it will throw an error because `logging.log` expects two inputs but receives only one.

This diff switches to `log.info` to resolve this issue.

Differential Revision: D28386343

