### PR TITLE
Make value in Constant not be a buffer

### DIFF
--- a/crypten/nn/module.py
+++ b/crypten/nn/module.py
@@ -881,8 +881,7 @@ class Constant(Module):
         assert torch.is_tensor(
             value
         ), f"value must be PyTorch tensor, not {type(value)}"
-        value = value.to(dtype=torch.float)
-        self.register_buffer("value", value)
+        self.value = value.to(dtype=torch.float)
 
     def forward(self, input):
         return self.value
@@ -913,8 +912,7 @@ class ConstantOfShape(Module):
         assert torch.is_tensor(
             value
         ), f"value must be PyTorch tensor, not {type(value)}"
-        value = value.to(dtype=torch.float)
-        self.register_buffer("value", value)
+        self.value = value.to(dtype=torch.float)
 
     def forward(self, size):
         if torch.is_tensor(size):


### PR DESCRIPTION
Summary:
At present, `value` in `Constant{OfShape}` is a buffer. This means it gets copied to GPU when a model gets copied. But, in practice, we only use it to concatenate values to a `Shape`, which is not a buffer and always remains on CPU (as it should). This leads to problems, for example, in vision transformers we end up concatenating a CPU tensor (from `Shape`) with a GPU tensor (from `Constant`).

I don't know what the right solution here is long-term, but this seems to work for fine in practice.

Differential Revision: D28444998

