### PR TITLE
Fix issue where the _logging decorator changed functions' names.

### DIFF
--- a/crypten/communicator/communicator.py
+++ b/crypten/communicator/communicator.py
@@ -146,7 +146,9 @@ class Communicator:
 
 def _logging(func):
     """Decorator that performs logging of communication statistics."""
+    from functools import wraps
 
+    @wraps(func)
     def logging_wrapper(self, *args, **kwargs):
 
         # TODO: Replace this


### PR DESCRIPTION
Use functools.wraps inside _logging so that the decorated function has
the same name that it originally had.

Closes #266.

## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

Fixes a problem where `@_logging` would change the name of all of the functions it wrapped to `"logging_wrapper"` (see #266).

## How Has This Been Tested (if it applies)

- Tested manually to check that wrappped communicator functions keep their original names.

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] The documentation is up-to-date with the changes I made.
- [X] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
