### PR TITLE
Make PRSS and A2B more memory-efficient

### DIFF
--- a/crypten/__init__.py
+++ b/crypten/__init__.py
@@ -15,7 +15,7 @@ import warnings
 
 import crypten.common  # noqa: F401
 import crypten.communicator as comm
-import crypten.models  # noqa: F401
+# import crypten.models  # noqa: F401
 import crypten.mpc  # noqa: F401
 import crypten.nn  # noqa: F401
 import crypten.optim  # noqa: F401

--- a/crypten/mpc/primitives/converters.py
+++ b/crypten/mpc/primitives/converters.py
@@ -16,13 +16,10 @@ from .binary import BinarySharedTensor
 
 
 def _A2B(arithmetic_tensor):
-    binary_tensor = BinarySharedTensor.stack(
-        [
-            BinarySharedTensor(arithmetic_tensor.share, src=i)
-            for i in range(comm.get().get_world_size())
-        ]
-    )
-    binary_tensor = binary_tensor.sum(dim=0)
+    binary_tensor = None
+    for i in range(comm.get().get_world_size()):
+        binary_share = BinarySharedTensor(arithmetic_tensor.share, src=i)
+        binary_tensor = binary_share if i == 0 else binary_tensor + binary_share
     binary_tensor.encoder = arithmetic_tensor.encoder
     return binary_tensor
 


### PR DESCRIPTION
Summary: The current PRSS and A2B implementations create a list of all tensors for all parties before performing the reduction via (arithmetic or binary) addition. This leads to memory issues when the number of parties involved in the computation is large and the tensors live on GPU (in which case all the tensors live on the same GPU). This diff replaces the existing implementation by an implementations that samples tensors one-by-one and performs the reduction on-the-fly.

Differential Revision: D28651728

