### PR TITLE
Update mpc_cifar example

### DIFF
--- a/examples/mpc_cifar/mpc_cifar.py
+++ b/examples/mpc_cifar/mpc_cifar.py
@@ -348,7 +348,7 @@ def accuracy(output, target, topk=(1,)):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].flatten().float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 


### PR DESCRIPTION
Summary: Seeing CircleCI failures in mpc_cifar due to `view(-1)` issue. I vaguely remember fixing this in an earlier PR, but perhaps it didn't land.

Differential Revision: D28720568

