### PR TITLE
Update PyCon ipynb for model training

### DIFF
--- a/pycon-workshop-2020/2 - Training a Model on Encrypted Data.ipynb
+++ b/pycon-workshop-2020/2 - Training a Model on Encrypted Data.ipynb
@@ -11,7 +11,15 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:module 'torchvision.models.mobilenet' has no attribute 'ConvBNReLU'\n"
+     ]
+    }
+   ],
    "source": [
     "import sys\n",
     "import torch\n",
@@ -60,7 +68,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x13193bb90>"
+       "<matplotlib.image.AxesImage at 0x7fd1e9ef9750>"
       ]
      },
      "execution_count": 3,
@@ -69,7 +77,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAN9klEQVR4nO3df4xV9ZnH8c+zWP6QojBrOhKKSyEGg8ZON4gbl6w1hvojGhw1TSexoZE4/YNJaLIhNewf1WwwZBU2SzTNTKMWNl1qEzUgaQouoOzGhDgiKo5LdQ2mTEaowZEf/mCHefaPezBTnfu9w7nn3nOZ5/1Kbu6957nnnicnfDi/7pmvubsATH5/VXYDAJqDsANBEHYgCMIOBEHYgSAuaubCzIxT/0CDubuNN72uLbuZ3Wpmh8zsPTN7sJ7vAtBYlvc6u5lNkfRHSUslHZH0qqQudx9IzMOWHWiwRmzZF0t6z93fd/czkn4raVkd3weggeoJ+2xJfxrz/kg27S+YWbeZ9ZtZfx3LAlCnhp+gc/c+SX0Su/FAmerZsg9KmjPm/bezaQBaUD1hf1XSlWb2HTObKulHkrYV0xaAouXejXf3ETPrkbRD0hRJT7n724V1BqBQuS+95VoYx+xAwzXkRzUALhyEHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIQdCIKwA0EQdiAIwg4EQdiBIAg7EARhB4Ig7EAQhB0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQiCsANBEHYgCMIOBJF7yGZcGKZMmZKsX3rppQ1dfk9PT9XaxRdfnJx3wYIFyfrKlSuT9ccee6xqraurKznv559/nqyvW7cuWX/44YeT9TLUFXYzOyzppKSzkkbcfVERTQEoXhFb9pvc/aMCvgdAA3HMDgRRb9hd0k4ze83Musf7gJl1m1m/mfXXuSwAdah3N36Juw+a2bckvWhm/+Pue8d+wN37JPVJkpl5ncsDkFNdW3Z3H8yej0l6XtLiIpoCULzcYTezaWY2/dxrST+QdLCoxgAUq57d+HZJz5vZue/5D3f/QyFdTTJXXHFFsj516tRk/YYbbkjWlyxZUrU2Y8aM5Lz33HNPsl6mI0eOJOsbN25M1js7O6vWTp48mZz3jTfeSNZffvnlZL0V5Q67u78v6bsF9gKggbj0BgRB2IEgCDsQBGEHgiDsQBDm3rwftU3WX9B1dHQk67t3707WG32baasaHR1N1u+///5k/dSpU7mXPTQ0lKx//PHHyfqhQ4dyL7vR3N3Gm86WHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeC4Dp7Adra2pL1ffv2Jevz5s0rsp1C1ep9eHg4Wb/pppuq1s6cOZOcN+rvD+rFdXYgOMIOBEHYgSAIOxAEYQeCIOxAEIQdCIIhmwtw/PjxZH316tXJ+h133JGsv/7668l6rT+pnHLgwIFkfenSpcn66dOnk/Wrr766am3VqlXJeVEstuxAEIQdCIKwA0EQdiAIwg4EQdiBIAg7EAT3s7eASy65JFmvNbxwb29v1dqKFSuS8953333J+pYtW5J1tJ7c97Ob2VNmdszMDo6Z1mZmL5rZu9nzzCKbBVC8iezG/1rSrV+Z9qCkXe5+paRd2XsALaxm2N19r6Sv/h50maRN2etNku4quC8ABcv72/h2dz83WNaHktqrfdDMuiV151wOgILUfSOMu3vqxJu790nqkzhBB5Qp76W3o2Y2S5Ky52PFtQSgEfKGfZuk5dnr5ZK2FtMOgEapuRtvZlskfV/SZWZ2RNIvJK2T9DszWyHpA0k/bGSTk92JEyfqmv+TTz7JPe8DDzyQrD/zzDPJeq0x1tE6aobd3buqlG4uuBcADcTPZYEgCDsQBGEHgiDsQBCEHQiCW1wngWnTplWtvfDCC8l5b7zxxmT9tttuS9Z37tyZrKP5GLIZCI6wA0EQdiAIwg4EQdiBIAg7EARhB4LgOvskN3/+/GR9//79yfrw8HCyvmfPnmS9v7+/au2JJ55IztvMf5uTCdfZgeAIOxAEYQeCIOxAEIQdCIKwA0EQdiAIrrMH19nZmaw//fTTyfr06dNzL3vNmjXJ+ubNm5P1oaGhZD0qrrMDwRF2IAjCDgRB2IEgCDsQBGEHgiDsQBBcZ0fSNddck6xv2LAhWb/55vyD/fb29ibra9euTdYHBwdzL/tClvs6u5k9ZWbHzOzgmGkPmdmgmR3IHrcX2SyA4k1kN/7Xkm4dZ/q/untH9vh9sW0BKFrNsLv7XknHm9ALgAaq5wRdj5m9me3mz6z2ITPrNrN+M6v+x8gANFzesP9S0nxJHZKGJK2v9kF373P3Re6+KOeyABQgV9jd/ai7n3X3UUm/krS42LYAFC1X2M1s1pi3nZIOVvssgNZQ8zq7mW2R9H1Jl0k6KukX2fsOSS7psKSfunvNm4u5zj75zJgxI1m/8847q9Zq3StvNu7l4i/t3r07WV+6dGmyPllVu85+0QRm7Bpn8pN1dwSgqfi5LBAEYQeCIOxAEIQdCIKwA0FwiytK88UXXyTrF12Uvlg0MjKSrN9yyy1Vay+99FJy3gsZf0oaCI6wA0EQdiAIwg4EQdiBIAg7EARhB4KoedcbYrv22muT9XvvvTdZv+6666rWal1Hr2VgYCBZ37t3b13fP9mwZQeCIOxAEIQdCIKwA0EQdiAIwg4EQdiBILjOPsktWLAgWe/p6UnW77777mT98ssvP++eJurs2bPJ+tBQ+q+Xj46OFtnOBY8tOxAEYQeCIOxAEIQdCIKwA0EQdiAIwg4EwXX2C0Cta9ldXeMNtFtR6zr63Llz87RUiP7+/mR97dq1yfq2bduKbGfSq7llN7M5ZrbHzAbM7G0zW5VNbzOzF83s3ex5ZuPbBZDXRHbjRyT9o7svlPR3klaa2UJJD0ra5e5XStqVvQfQomqG3d2H3H1/9vqkpHckzZa0TNKm7GObJN3VqCYB1O+8jtnNbK6k70naJ6nd3c/9OPlDSe1V5umW1J2/RQBFmPDZeDP7pqRnJf3M3U+MrXlldMhxB2109z53X+Tui+rqFEBdJhR2M/uGKkH/jbs/l00+amazsvosScca0yKAItTcjTczk/SkpHfcfcOY0jZJyyWty563NqTDSaC9fdwjnC8tXLgwWX/88ceT9auuuuq8eyrKvn37kvVHH320am3r1vQ/GW5RLdZEjtn/XtKPJb1lZgeyaWtUCfnvzGyFpA8k/bAxLQIoQs2wu/t/Sxp3cHdJNxfbDoBG4eeyQBCEHQiCsANBEHYgCMIOBMEtrhPU1tZWtdbb25uct6OjI1mfN29erp6K8MorryTr69evT9Z37NiRrH/22Wfn3RMagy07EARhB4Ig7EAQhB0IgrADQRB2IAjCDgQR5jr79ddfn6yvXr06WV+8eHHV2uzZs3P1VJRPP/20am3jxo3JeR955JFk/fTp07l6Quthyw4EQdiBIAg7EARhB4Ig7EAQhB0IgrADQYS5zt7Z2VlXvR4DAwPJ+vbt25P1kZGRZD11z/nw8HByXsTBlh0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgjB3T3/AbI6kzZLaJbmkPnf/NzN7SNIDkv6cfXSNu/++xnelFwagbu4+7qjLEwn7LEmz3H2/mU2X9Jqku1QZj/2Uuz820SYIO9B41cI+kfHZhyQNZa9Pmtk7ksr90ywAztt5HbOb2VxJ35O0L5vUY2ZvmtlTZjazyjzdZtZvZv11dQqgLjV347/8oNk3Jb0saa27P2dm7ZI+UuU4/p9V2dW/v8Z3sBsPNFjuY3ZJMrNvSNouaYe7bxinPlfSdne/psb3EHagwaqFveZuvJmZpCclvTM26NmJu3M6JR2st0kAjTORs/FLJP2XpLckjWaT10jqktShym78YUk/zU7mpb6LLTvQYHXtxheFsAONl3s3HsDkQNiBIAg7EARhB4Ig7EAQhB0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQii2UM2fyTpgzHvL8umtaJW7a1V+5LoLa8ie/ubaoWm3s/+tYWb9bv7otIaSGjV3lq1L4ne8mpWb+zGA0EQdiCIssPeV/LyU1q1t1btS6K3vJrSW6nH7ACap+wtO4AmIexAEKWE3cxuNbNDZvaemT1YRg/VmNlhM3vLzA6UPT5dNobeMTM7OGZam5m9aGbvZs/jjrFXUm8Pmdlgtu4OmNntJfU2x8z2mNmAmb1tZquy6aWuu0RfTVlvTT9mN7Mpkv4oaamkI5JeldTl7gNNbaQKMzssaZG7l/4DDDP7B0mnJG0+N7SWmf2LpOPuvi77j3Kmu/+8RXp7SOc5jHeDeqs2zPhPVOK6K3L48zzK2LIvlvSeu7/v7mck/VbSshL6aHnuvlfS8a9MXiZpU/Z6kyr/WJquSm8twd2H3H1/9vqkpHPDjJe67hJ9NUUZYZ8t6U9j3h9Ra4337pJ2mtlrZtZddjPjaB8zzNaHktrLbGYcNYfxbqavDDPeMusuz/Dn9eIE3dctcfe/lXSbpJXZ7mpL8soxWCtdO/2lpPmqjAE4JGl9mc1kw4w/K+ln7n5ibK3MdTdOX01Zb2WEfVDSnDHvv51NawnuPpg9H5P0vCqHHa3k6LkRdLPnYyX38yV3P+ruZ919VNKvVOK6y4YZf1bSb9z9uWxy6etuvL6atd7KCPurkq40s++Y2VRJP5K0rYQ+vsbMpmUnTmRm0yT9QK03FPU2Scuz18slbS2xl7/QKsN4VxtmXCWvu9KHP3f3pj8k3a7KGfn/lfRPZfRQpa95kt7IHm+X3ZukLars1v2fKuc2Vkj6a0m7JL0r6T8ltbVQb/+uytDeb6oSrFkl9bZElV30NyUdyB63l73uEn01Zb3xc1kgCE7QAUEQdiAIwg4EQdiBIAg7EARhB4Ig7EAQ/w8ie3GmjcGk5QAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAN8klEQVR4nO3df6jVdZ7H8ddrbfojxzI39iZOrWOEUdE6i9nSyjYRTj8o7FYMIzQ0JDl/JDSwyIb7xxSLIVu6rBSDDtXYMus0UJHFMNVm5S6BdDMrs21qoxjlphtmmv1a9b1/3K9xp+75nOs53/PD+34+4HDO+b7P93zffPHl99f53o8jQgAmvj/rdQMAuoOwA0kQdiAJwg4kQdiBJE7o5sJsc+of6LCI8FjT29qy277C9lu237F9ezvfBaCz3Op1dtuTJP1B0gJJOyW9JGlRROwozMOWHeiwTmzZ50l6JyLejYgvJf1G0sI2vg9AB7UT9hmS/jjq/c5q2p+wvcT2kO2hNpYFoE0dP0EXEeskrZPYjQd6qZ0t+y5JZ4x6/51qGoA+1E7YX5J0tu3v2j5R0o8kbaynLQB1a3k3PiIO2V4q6SlJkyQ9EBFv1NYZgFq1fOmtpYVxzA50XEd+VAPg+EHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEi0P2Yzjw6RJk4r1U045paPLX7p0acPaSSedVJx39uzZxfqtt95arN9zzz0Na4sWLSrO+/nnnxfrK1euLNbvvPPOYr0X2gq77fckHZB0WNKhiJhbR1MA6lfHlv3SiPiwhu8B0EEcswNJtBv2kPS07ZdtLxnrA7aX2B6yPdTmsgC0od3d+PkRscv2X0h6xvZ/R8Tm0R+IiHWS1kmS7WhzeQBa1NaWPSJ2Vc97JD0maV4dTQGoX8thtz3Z9pSjryX9QNL2uhoDUK92duMHJD1m++j3/HtE/L6WriaYM888s1g/8cQTi/WLL764WJ8/f37D2tSpU4vzXn/99cV6L+3cubNYX7NmTbE+ODjYsHbgwIHivK+++mqx/sILLxTr/ajlsEfEu5L+qsZeAHQQl96AJAg7kARhB5Ig7EAShB1IwhHd+1HbRP0F3Zw5c4r1TZs2Feudvs20Xx05cqRYv/nmm4v1Tz75pOVlDw8PF+sfffRRsf7WW2+1vOxOiwiPNZ0tO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kwXX2GkybNq1Y37JlS7E+a9asOtupVbPe9+3bV6xfeumlDWtffvllcd6svz9oF9fZgeQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJhmyuwd69e4v1ZcuWFetXX311sf7KK68U683+pHLJtm3bivUFCxYU6wcPHizWzzvvvIa12267rTgv6sWWHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeS4H72PnDyyScX682GF167dm3D2uLFi4vz3njjjcX6hg0binX0n5bvZ7f9gO09trePmjbN9jO2366eT62zWQD1G89u/K8kXfG1abdLejYizpb0bPUeQB9rGvaI2Czp678HXShpffV6vaRr620LQN1a/W38QEQcHSzrA0kDjT5oe4mkJS0uB0BN2r4RJiKidOItItZJWidxgg7opVYvve22PV2Squc99bUEoBNaDftGSTdVr2+S9Hg97QDolKa78bY3SPq+pNNs75T0c0krJf3W9mJJ70v6YSebnOj279/f1vwff/xxy/PecsstxfrDDz9crDcbYx39o2nYI2JRg9JlNfcCoIP4uSyQBGEHkiDsQBKEHUiCsANJcIvrBDB58uSGtSeeeKI47yWXXFKsX3nllcX6008/Xayj+xiyGUiOsANJEHYgCcIOJEHYgSQIO5AEYQeS4Dr7BHfWWWcV61u3bi3W9+3bV6w/99xzxfrQ0FDD2n333Vect5v/NicSrrMDyRF2IAnCDiRB2IEkCDuQBGEHkiDsQBJcZ09ucHCwWH/wwQeL9SlTprS87OXLlxfrDz30ULE+PDxcrGfFdXYgOcIOJEHYgSQIO5AEYQeSIOxAEoQdSILr7Cg6//zzi/XVq1cX65dd1vpgv2vXri3WV6xYUazv2rWr5WUfz1q+zm77Adt7bG8fNe0O27tsb6seV9XZLID6jWc3/leSrhhj+r9ExJzq8bt62wJQt6Zhj4jNkvZ2oRcAHdTOCbqltl+rdvNPbfQh20tsD9lu/MfIAHRcq2H/haSzJM2RNCxpVaMPRsS6iJgbEXNbXBaAGrQU9ojYHRGHI+KIpF9KmldvWwDq1lLYbU8f9XZQ0vZGnwXQH5peZ7e9QdL3JZ0mabekn1fv50gKSe9J+mlENL25mOvsE8/UqVOL9WuuuaZhrdm98vaYl4u/smnTpmJ9wYIFxfpE1eg6+wnjmHHRGJPvb7sjAF3Fz2WBJAg7kARhB5Ig7EAShB1Igltc0TNffPFFsX7CCeWLRYcOHSrWL7/88oa1559/vjjv8Yw/JQ0kR9iBJAg7kARhB5Ig7EAShB1IgrADSTS96w25XXDBBcX6DTfcUKxfeOGFDWvNrqM3s2PHjmJ98+bNbX3/RMOWHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeS4Dr7BDd79uxifenSpcX6ddddV6yffvrpx9zTeB0+fLhYHx4u//XyI0eO1NnOcY8tO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kwXX240Cza9mLFo010O6IZtfRZ86c2UpLtRgaGirWV6xYUaxv3LixznYmvKZbdttn2H7O9g7bb9i+rZo+zfYztt+unk/tfLsAWjWe3fhDkv4+Is6V9DeSbrV9rqTbJT0bEWdLerZ6D6BPNQ17RAxHxNbq9QFJb0qaIWmhpPXVx9ZLurZDPQKowTEds9ueKel7krZIGoiIoz9O/kDSQIN5lkha0kaPAGow7rPxtr8t6RFJP4uI/aNrMTI65JiDNkbEuoiYGxFz2+oUQFvGFXbb39JI0H8dEY9Wk3fbnl7Vp0va05kWAdSh6W68bUu6X9KbEbF6VGmjpJskrayeH+9IhxPAwMCYRzhfOffcc4v1e++9t1g/55xzjrmnumzZsqVYv/vuuxvWHn+8/E+GW1TrNZ5j9r+V9GNJr9veVk1brpGQ/9b2YknvS/phRzoEUIumYY+I/5I05uDuki6rtx0AncLPZYEkCDuQBGEHkiDsQBKEHUiCW1zHadq0aQ1ra9euLc47Z86cYn3WrFmttFSLF198sVhftWpVsf7UU08V65999tkx94TOYMsOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0mkuc5+0UUXFevLli0r1ufNm9ewNmPGjJZ6qsunn37asLZmzZrivHfddVexfvDgwZZ6Qv9hyw4kQdiBJAg7kARhB5Ig7EAShB1IgrADSaS5zj44ONhWvR07duwo1p988sli/dChQ8V66Z7zffv2FedFHmzZgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJR0T5A/YZkh6SNCApJK2LiH+1fYekWyT9b/XR5RHxuybfVV4YgLZFxJijLo8n7NMlTY+IrbanSHpZ0rUaGY/9k4i4Z7xNEHag8xqFfTzjsw9LGq5eH7D9pqTe/mkWAMfsmI7Zbc+U9D1JW6pJS22/ZvsB26c2mGeJ7SHbQ+21CqAdTXfjv/qg/W1JL0haERGP2h6Q9KFGjuP/SSO7+jc3+Q5244EOa/mYXZJsf0vSk5KeiojVY9RnSnoyIs5v8j2EHeiwRmFvuhtv25Lul/Tm6KBXJ+6OGpS0vd0mAXTOeM7Gz5f0n5Jel3Skmrxc0iJJczSyG/+epJ9WJ/NK38WWHeiwtnbj60LYgc5reTcewMRA2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSKLbQzZ/KOn9Ue9Pq6b1o37trV/7kuitVXX29peNCl29n/0bC7eHImJuzxoo6Nfe+rUvid5a1a3e2I0HkiDsQBK9Dvu6Hi+/pF9769e+JHprVVd66+kxO4Du6fWWHUCXEHYgiZ6E3fYVtt+y/Y7t23vRQyO237P9uu1tvR6frhpDb4/t7aOmTbP9jO23q+cxx9jrUW932N5Vrbtttq/qUW9n2H7O9g7bb9i+rZre03VX6Ksr663rx+y2J0n6g6QFknZKeknSoojY0dVGGrD9nqS5EdHzH2DY/jtJn0h66OjQWrb/WdLeiFhZ/Ud5akT8Q5/0doeOcRjvDvXWaJjxn6iH667O4c9b0Yst+zxJ70TEuxHxpaTfSFrYgz76XkRslrT3a5MXSlpfvV6vkX8sXdegt74QEcMRsbV6fUDS0WHGe7ruCn11RS/CPkPSH0e936n+Gu89JD1t+2XbS3rdzBgGRg2z9YGkgV42M4amw3h309eGGe+bddfK8Oft4gTdN82PiL+WdKWkW6vd1b4UI8dg/XTt9BeSztLIGIDDklb1splqmPFHJP0sIvaPrvVy3Y3RV1fWWy/CvkvSGaPef6ea1hciYlf1vEfSYxo57Ognu4+OoFs97+lxP1+JiN0RcTgijkj6pXq47qphxh+R9OuIeLSa3PN1N1Zf3VpvvQj7S5LOtv1d2ydK+pGkjT3o4xtsT65OnMj2ZEk/UP8NRb1R0k3V65skPd7DXv5Evwzj3WiYcfV43fV8+POI6PpD0lUaOSP/P5L+sRc9NOhrlqRXq8cbve5N0gaN7Nb9n0bObSyW9OeSnpX0tqT/kDStj3r7N40M7f2aRoI1vUe9zdfILvprkrZVj6t6ve4KfXVlvfFzWSAJTtABSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBL/DyJ7caZa7LphAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -138,7 +146,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "images, labels = take_samples(digits, n_samples=100)"
+    "images, labels = take_samples(digits, n_samples=100)\n",
+    "images = images.unsqueeze(1)"
    ]
   },
   {
@@ -150,7 +159,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "torch.Size([100, 28, 28])\n",
+      "torch.Size([100, 1, 28, 28])\n",
       "torch.Size([100, 10])\n"
      ]
     }
@@ -179,90 +188,90 @@
      "data": {
       "text/plain": [
        "MPCTensor(\n",
-       "\t_tensor=tensor([[    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,   771,  4626,  4626,  4626, 32382, 34952, 44975,  6682,\n",
-       "         42662, 65536, 63479, 32639,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,  7710,  9252,\n",
-       "         24158, 39578, 43690, 65021, 65021, 65021, 65021, 65021, 57825, 44204,\n",
-       "         65021, 62194, 50115, 16448,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0, 12593, 61166, 65021,\n",
-       "         65021, 65021, 65021, 65021, 65021, 65021, 65021, 64507, 23901, 21074,\n",
-       "         21074, 14392, 10023,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,  4626, 56283, 65021,\n",
-       "         65021, 65021, 65021, 65021, 50886, 46774, 63479, 61937,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0, 20560, 40092,\n",
-       "         27499, 65021, 65021, 52685,  2827,     0, 11051, 39578,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,  3598,\n",
-       "           257, 39578, 65021, 23130,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0, 35723, 65021, 48830,   514,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,  2827, 48830, 65021, 17990,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,  8995, 61937, 57825, 41120, 27756,   257,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0, 20817, 61680, 65021, 65021, 30583,  6425,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0, 11565, 47802, 65021, 65021, 38550,  6939,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,  4112, 23901, 64764, 65021, 48059,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0, 63993, 65021, 63993,\n",
-       "         16448,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0, 11822, 33410, 47031, 65021, 65021, 53199,\n",
-       "           514,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0, 10023, 38036, 58853, 65021, 65021, 65021, 64250, 46774,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "          6168, 29298, 56797, 65021, 65021, 65021, 65021, 51657, 20046,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,  5911, 16962,\n",
-       "         54741, 65021, 65021, 65021, 65021, 50886, 20817,   514,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,  4626, 43947, 56283, 65021,\n",
-       "         65021, 65021, 65021, 50115, 20560,  2313,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0, 14135, 44204, 58082, 65021, 65021, 65021,\n",
-       "         65021, 62708, 34181,  2827,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0, 34952, 65021, 65021, 65021, 54484, 34695,\n",
-       "         33924,  4112,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0],\n",
-       "        [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
-       "             0,     0,     0,     0,     0,     0,     0,     0]])\n",
+       "\t_tensor=tensor([[[    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,   771,  4626,  4626,  4626, 32382, 34952, 44975,  6682,\n",
+       "          42662, 65536, 63479, 32639,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,  7710,  9252,\n",
+       "          24158, 39578, 43690, 65021, 65021, 65021, 65021, 65021, 57825, 44204,\n",
+       "          65021, 62194, 50115, 16448,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0, 12593, 61166, 65021,\n",
+       "          65021, 65021, 65021, 65021, 65021, 65021, 65021, 64507, 23901, 21074,\n",
+       "          21074, 14392, 10023,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,  4626, 56283, 65021,\n",
+       "          65021, 65021, 65021, 65021, 50886, 46774, 63479, 61937,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0, 20560, 40092,\n",
+       "          27499, 65021, 65021, 52685,  2827,     0, 11051, 39578,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,  3598,\n",
+       "            257, 39578, 65021, 23130,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0, 35723, 65021, 48830,   514,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,  2827, 48830, 65021, 17990,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,  8995, 61937, 57825, 41120, 27756,   257,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0, 20817, 61680, 65021, 65021, 30583,  6425,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0, 11565, 47802, 65021, 65021, 38550,  6939,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,  4112, 23901, 64764, 65021, 48059,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0, 63993, 65021, 63993,\n",
+       "          16448,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0, 11822, 33410, 47031, 65021, 65021, 53199,\n",
+       "            514,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0, 10023, 38036, 58853, 65021, 65021, 65021, 64250, 46774,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "           6168, 29298, 56797, 65021, 65021, 65021, 65021, 51657, 20046,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,  5911, 16962,\n",
+       "          54741, 65021, 65021, 65021, 65021, 50886, 20817,   514,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,  4626, 43947, 56283, 65021,\n",
+       "          65021, 65021, 65021, 50115, 20560,  2313,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0, 14135, 44204, 58082, 65021, 65021, 65021,\n",
+       "          65021, 62708, 34181,  2827,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0, 34952, 65021, 65021, 65021, 54484, 34695,\n",
+       "          33924,  4112,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0],\n",
+       "         [    0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0,     0,     0,\n",
+       "              0,     0,     0,     0,     0,     0,     0,     0]]])\n",
        "\tplain_text=HIDDEN\n",
        "\tptype=ptype.arithmetic\n",
        ")"
@@ -300,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,14 +321,14 @@
     "        self.linear = crypten.nn.Linear(28 * 28, 10)\n",
     "        \n",
     "    def forward(self, x):\n",
-    "        return self.linear(x)\n",
+    "        return self.linear(x.flatten(start_dim=1))\n",
     "        \n",
     "    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,16 +337,219 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<crypten.autograd_cryptensor.AutogradCrypTensor object at 0x12908bbd0>"
+       "MPCTensor(\n",
+       "\t_tensor=tensor([[ -7212,  -4832, -18332,  -1289, -14345, -10329, -20953,  17165, -26486,\n",
+       "           7973],\n",
+       "        [ -4941,  14792, -17722,  21735,  -9983,   4587,  -4442,  11390, -44190,\n",
+       "            122],\n",
+       "        [ 11571,  17364,    995,  12531, -13151,  13358,  -6799,  -5498, -10863,\n",
+       "         -12377],\n",
+       "        [ 12576,  -8088, -12991,  -4375,  -6995,  -5857,   2563,   3591, -20752,\n",
+       "            685],\n",
+       "        [ -2223,   4062,  -8420,   5543, -14815,  12751,   5019,  17012, -18646,\n",
+       "          13673],\n",
+       "        [ -8783,   8678, -12389,  17346,   1583,  22358,  -4514,   4856, -41324,\n",
+       "           7442],\n",
+       "        [  1564,  10381,   8001,   -848, -13249,  16488,   7019,  14232,   -692,\n",
+       "          17547],\n",
+       "        [  5243,  23551, -15260,  28311,  -8729,  14170, -14053,   1791, -33591,\n",
+       "          11378],\n",
+       "        [  2616,   -294,    833,  -8909, -18784,  12657,   8126,  17566,   6428,\n",
+       "          17520],\n",
+       "        [  3399,   4754,   -566,  12797,   6129,  14565,   6011,  12069, -16259,\n",
+       "          -5706],\n",
+       "        [   865,  11821,   -620,  16376, -21973,  17541,  -5663,  10869, -13874,\n",
+       "          18923],\n",
+       "        [ 11869,   -440,  -4881,  20986,   5914,   5042,  12150,   3967, -24299,\n",
+       "            637],\n",
+       "        [  7612,  13537,   -109,   5460, -28395,   9418,  -7524,   4946, -32486,\n",
+       "          -3631],\n",
+       "        [  1019,   7641,  10418,  -5475, -26059,  20746,   6024,  22127,  -5551,\n",
+       "          11373],\n",
+       "        [  2466,   4393,  -2303,  -5742, -17815,  14474,  10662,  17065,   1807,\n",
+       "           9591],\n",
+       "        [  7242,  17784,  -7460,  12391, -12229,  10155, -14227,   8442, -27495,\n",
+       "          -7123],\n",
+       "        [ -7222,  -4973,   1569,  27344,   7290,  10289, -20722,  -2878, -13358,\n",
+       "          12340],\n",
+       "        [ -5855,   4273,  -7624,   2729,  -5141,   8021,  -1459,  11308, -26404,\n",
+       "          -2546],\n",
+       "        [ 11004,   5733,    994, -14600,    500,   8528,  -3840,  11112, -24731,\n",
+       "           2472],\n",
+       "        [  2431,   9442,   2985,   1486, -11549,  11199,   2648,  20748, -19516,\n",
+       "          -6030],\n",
+       "        [   487,   3180,   9879,   8938,  -5495,  -4019,  -5690,  12277, -16134,\n",
+       "           2874],\n",
+       "        [ -7025,  13082, -21187,  27813,  -4597,   1034,  -1547,  -3074, -55812,\n",
+       "            739],\n",
+       "        [  -278,   9946,  -1842,   1382,  -5491,  15155,  -4391,  15079,  -9871,\n",
+       "          -5589],\n",
+       "        [ 10266,  -3644, -10969,  -1807,  -9206,  -3307,   3722,   4451, -21254,\n",
+       "           1546],\n",
+       "        [   839,  10198, -25629,   7534, -13437,   7138,  -5762,   6140, -10215,\n",
+       "          -4432],\n",
+       "        [ -3813,  11817, -15032,   9683,   5505,  29148, -16020,  -3277, -50608,\n",
+       "           5202],\n",
+       "        [  7283,  -2217,  -5354,   5192, -14104,   2477, -13669,  -6474,   1786,\n",
+       "          10925],\n",
+       "        [ -4052,  21655, -22230,  29691, -16029,  19392, -18390,   4031, -39273,\n",
+       "           4260],\n",
+       "        [  8203,   1299, -14743,  28712,  -8870,  25171,   6966,  13567, -41517,\n",
+       "          15202],\n",
+       "        [  4045,   5149, -15383,   -601, -12744,  13553,   6535,  13946,  -3504,\n",
+       "           2127],\n",
+       "        [  5116, -11364,  -1532, -11052, -33686,   -681, -15976,  -7463,  -4338,\n",
+       "           -859],\n",
+       "        [ -7461,  18290, -22552,  12466,  10825,  27055,   3000,  10431, -27756,\n",
+       "          11504],\n",
+       "        [ 15689,  17611,   -224,   -420, -13338,  -5298, -13414,   -530, -16874,\n",
+       "          16535],\n",
+       "        [ -1491,  13933,  -3639,   3535,  -9286,  15598,   4458,  17314, -24089,\n",
+       "           3538],\n",
+       "        [  6527,  12070, -12584,  22085,      2,   7917, -13291,    175, -34555,\n",
+       "           7671],\n",
+       "        [ 18645,  10698, -20525,  -1852, -12665,   2945,   1275, -13533, -24534,\n",
+       "          -4238],\n",
+       "        [  9435,  14764, -11948,  -1134, -19716,   6408,  -4725,  10729, -24008,\n",
+       "           9377],\n",
+       "        [ 13227,  16275,  -4673,  24837,   6178,  11206,   -773,   2628, -52492,\n",
+       "           3500],\n",
+       "        [ -8346,  -9538,   2369,    695,  -7828,   5649,  -4269,  -3974,   1657,\n",
+       "          17428],\n",
+       "        [  9839,  17904,   1678,   4033, -16953,  10286,  -7804,  11867, -17010,\n",
+       "          17216],\n",
+       "        [ -8503,  12733,   3261,  -2763,  -6974,  16498,   4752,  14991, -12935,\n",
+       "           9614],\n",
+       "        [ -9338,  -4039,  -4666,   4594,  -6083,   5659,  -2741,   2552, -24829,\n",
+       "          13680],\n",
+       "        [ -6753,   7127,   1511,  -2686, -17491,   2928, -12413,   9446,  -5149,\n",
+       "          -1045],\n",
+       "        [ -8144,   8729,   2767,   -557, -11762,   4263,   -462,   6376, -19740,\n",
+       "           5165],\n",
+       "        [ -2953,  -1412,   1908,   9393,  -9103,  -2805,   8829,  -1026, -12202,\n",
+       "          11689],\n",
+       "        [ -8236,   6895,   5203,  10269,  -3918,   5958,  -4958,  11584, -13806,\n",
+       "           6130],\n",
+       "        [ -4653,   4637,   1112,  20567,   -873,  -8045,  -6659,   -336, -21891,\n",
+       "           7400],\n",
+       "        [  8363,  -1435,  -6531,  -3196,  -3541, -10244, -20117,   3787, -34045,\n",
+       "           6230],\n",
+       "        [ -2824,   7967,   -709,  10494, -18664,   8207,  -9563,  -4795,   -578,\n",
+       "           4122],\n",
+       "        [ 11044,  16684, -18007,  16236, -13508,   1412, -14879,  -1465, -37910,\n",
+       "           3065],\n",
+       "        [ -2062,  16253,   4289,  -1403,  -4351,  13487, -12187,   9155, -32442,\n",
+       "            449],\n",
+       "        [ -2396,  23243, -17470,  31221, -16252,   8536, -12260,    308, -74973,\n",
+       "           -769],\n",
+       "        [ -2008,   9115,    412,  31623, -13526,  -3470, -10338,   -893, -17899,\n",
+       "          13217],\n",
+       "        [  9569,  12331,  -3403,    -67, -28221,   7050,   3570,  17150,  -5087,\n",
+       "          -8627],\n",
+       "        [  -389,  15265,   8744,   8408, -14889,   2488, -11739,  -5181,  -9991,\n",
+       "          17528],\n",
+       "        [   539,  10017,  -9173,  11363, -19615,   6606,   2367,  18533, -22902,\n",
+       "          19123],\n",
+       "        [ -6319,  20110,  -8734,  22094, -17039,   8065,  -5312,   4163, -42530,\n",
+       "         -11896],\n",
+       "        [ -3059,  12861,   2074,   3073,  -3018,  12358,  -5950,   9052, -18595,\n",
+       "          -3406],\n",
+       "        [ -2282,  25933,   5303,  14407, -12462, -14758, -11056,    275, -25137,\n",
+       "           4092],\n",
+       "        [ -1088,  -3653,  -3484,  -1235,  -3111,  -4943,     12,   4700, -25892,\n",
+       "           1970],\n",
+       "        [-16102,  11788,    223,   7443,  -6631,   5038, -10592,  -8020, -12883,\n",
+       "           2572],\n",
+       "        [ 12547,  -1449,  -2672,   5714, -13713,   9836,   8387,   3930, -12374,\n",
+       "           4860],\n",
+       "        [ 12246,  15080,  -9261,   1249,  -9109,   6391,  -9425,  13571, -27376,\n",
+       "          10452],\n",
+       "        [-13407,  23190, -17070,  24148,    517,   5146,   9229,   1327, -53709,\n",
+       "          10483],\n",
+       "        [ 12316,  21915,   8578,  15366,  -6033,  -4849,   5626,   4169, -26689,\n",
+       "          12606],\n",
+       "        [  9738,   3588, -12187,  17044,    945,     24,  18965,   4595, -13743,\n",
+       "           3784],\n",
+       "        [  8679,  12745,   2080,   3195,  -9574,  13488,   2520,  10066, -15249,\n",
+       "           3408],\n",
+       "        [  1706,   4747,  -8175,  -2770, -10274,   1229,   3216,  14423, -17473,\n",
+       "          -3658],\n",
+       "        [-11017,  14004,   -522,  -2384,   2290,   6612, -12318,   2674, -17874,\n",
+       "          10371],\n",
+       "        [  6843,  26961,   -889,  29242,  -3086,  17668, -11271,    903, -52006,\n",
+       "           1585],\n",
+       "        [  3367,  13017,    -99,   -631, -19295,   8083,   2394,  16636,  -7754,\n",
+       "          13581],\n",
+       "        [ 11778,  11115, -10153,  13552,  -8972,  18082,  -3164,   3947, -17818,\n",
+       "          -5783],\n",
+       "        [ -3029,  15077,   3627,  -9648, -14198,  11524,   4470,  16911,  -8885,\n",
+       "           8876],\n",
+       "        [  5099,  11414,  -7662,  -1538, -17151,  18957,   9123,  20050,   3407,\n",
+       "           7743],\n",
+       "        [  -184,   8420,   2084,  10993, -22006,  10966,  -2514,   -596,  -4404,\n",
+       "          11007],\n",
+       "        [  1533,  13701,  -9184,  26398,   -464,  19695,    105,   8432, -54242,\n",
+       "           2016],\n",
+       "        [  6389,  11478,  -5823,   -955,   7669,  16234,   1532,   3048, -30707,\n",
+       "          13457],\n",
+       "        [  4877,   1911, -15712,    211,  -7068,  -4691,   1460,   5025, -17804,\n",
+       "          -1326],\n",
+       "        [ -6511,   4228,  -7110,  -5708, -10980,  10677,   4203,  15502, -30860,\n",
+       "           2891],\n",
+       "        [  8780,  11833, -22912,   5567,  -8783,  19688,   -282,  14711, -17239,\n",
+       "          -2702],\n",
+       "        [  -826,  38245,   3011,   9998,  -3775,  18834,  -4991,    217, -22396,\n",
+       "           5460],\n",
+       "        [ -2121,  17146, -14755,  24193,  -3601,  16455, -13377,  -1977, -46809,\n",
+       "           7285],\n",
+       "        [ 19164,  25303,  -8805,  27379,   6059,  34245,  -7883,  -1807, -51946,\n",
+       "          19156],\n",
+       "        [ -5535,  24455,   5675,   1677, -14452,   8533,  16982,  29174, -14165,\n",
+       "          13324],\n",
+       "        [ -3968,  -2377,  -9615,  11719,  -6303,   5271,   3397,   1178,  -6738,\n",
+       "          13682],\n",
+       "        [   841,   9637, -11046,  12713,   1654,  10850,  -7913,  -2963, -22851,\n",
+       "           8307],\n",
+       "        [ -3169,   6187, -13643,   -803, -22824,  16557,   4851,   8129,   5152,\n",
+       "           -788],\n",
+       "        [  2697,  17329,  -4350,   6123,   -403,  18276,  -4427,  10947, -18919,\n",
+       "           4631],\n",
+       "        [ -6854,  22521,  -1593,  24789,  -7175,  20710, -18236,  11271, -44893,\n",
+       "          -7735],\n",
+       "        [  6516,  17380,  -3585,   7665,   -676,   9383, -17343,   5269, -28214,\n",
+       "          -2340],\n",
+       "        [ 11690,  14025,    190,  -6676,  -5216,   5349, -10027,  16121, -29398,\n",
+       "          11126],\n",
+       "        [ 10085,  15044,  -3461,  21915,  -3637,   1462, -14881,   5748, -22443,\n",
+       "          -2661],\n",
+       "        [ -3934,   7810,   4486,  10074,   2273,  -6529,  -7624,  -4194, -13489,\n",
+       "          -1225],\n",
+       "        [   -59,  15031,   7341,  -9806, -20435,  20827,   6772,  23677, -20571,\n",
+       "          14433],\n",
+       "        [ -7376,  14636, -12920,   6909, -17675,   7119, -11259,  16738, -20831,\n",
+       "          16055],\n",
+       "        [   560,  20739,  -3204,  21799,  -3149,  19988, -10483,   8447, -53624,\n",
+       "           4706],\n",
+       "        [-13979,  12793,    889,  -1890,  -8276,   4375,  -9801,  10600, -15293,\n",
+       "           4127],\n",
+       "        [ -4332,  11891, -11204,   5391,  -6406,   4303,  -2888,  10858, -25701,\n",
+       "          16977],\n",
+       "        [  3059,   9240,   7874,  14940, -11241,   7371, -10035,  -2522, -13980,\n",
+       "           5813],\n",
+       "        [   432,   7946, -12631,  -4632,  -6783,   9721,  -1568,   8453, -20867,\n",
+       "           -216]])\n",
+       "\tplain_text=HIDDEN\n",
+       "\tptype=ptype.arithmetic\n",
+       ")"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -355,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,23 +586,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "epoch 0 loss: 2.332916259765625\n",
-      "epoch 1 loss: 2.2252349853515625\n",
-      "epoch 2 loss: 2.1306304931640625\n",
-      "epoch 3 loss: 2.0459747314453125\n",
-      "epoch 4 loss: 1.968963623046875\n",
-      "epoch 5 loss: 1.89739990234375\n",
-      "epoch 6 loss: 1.8313140869140625\n",
-      "epoch 7 loss: 1.7688751220703125\n",
-      "epoch 8 loss: 1.7100067138671875\n",
-      "epoch 9 loss: 1.6540679931640625\n"
+      "epoch 0 loss: 2.3475341796875\n",
+      "epoch 1 loss: 2.243408203125\n",
+      "epoch 2 loss: 2.1518096923828125\n",
+      "epoch 3 loss: 2.0686492919921875\n",
+      "epoch 4 loss: 1.9932098388671875\n",
+      "epoch 5 loss: 1.922882080078125\n",
+      "epoch 6 loss: 1.857452392578125\n",
+      "epoch 7 loss: 1.79583740234375\n",
+      "epoch 8 loss: 1.7375640869140625\n",
+      "epoch 9 loss: 1.6826324462890625\n"
      ]
     }
    ],
@@ -407,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -425,7 +637,7 @@
        "tensor(1)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -436,22 +648,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x131b099d0>"
+       "<matplotlib.image.AxesImage at 0x7fd1ea201e90>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAMb0lEQVR4nO3db4gc9R3H8c8ntkWIotHQM9rUtMUnUmwsQQo9SoppiCIkfRKaByXS0vNBlQoVIlaoUgqhVouIFq5o/pTWUog2oZS2NkRtCZacksaoidqQYI54VxGpeZTqfftgJ3LG29lzZ2Znk+/7Bcfuznd35suQT+bf7vwcEQJw7lvQdgMABoOwA0kQdiAJwg4kQdiBJD4xyIXZ5tQ/0LCI8FzTK23Zba+xfdj267bvrDIvAM1yv9fZbZ8n6VVJ35B0XNI+SRsi4uWSz7BlBxrWxJb9OkmvR8SRiDgl6XeS1laYH4AGVQn7FZLemPX6eDHtQ2yP2Z6wPVFhWQAqavwEXUSMSxqX2I0H2lRlyz4paems158ppgEYQlXCvk/SVbY/Z/tTkr4laVc9bQGoW9+78RHxnu1bJf1F0nmSHouIl2rrDECt+r701tfCOGYHGtfIl2oAnD0IO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSKLvIZuBpt19992l9Xvvvbe0vmBB923ZypUrSz/7zDPPlNbPRpXCbvuopHclvS/pvYhYUUdTAOpXx5b96xHxVg3zAdAgjtmBJKqGPST91fbztsfmeoPtMdsTticqLgtABVV340cjYtL2pyU9ZftQRDw7+w0RMS5pXJJsR8XlAehTpS17REwWj9OSnpR0XR1NAahf32G3vdD2haefS1ot6WBdjQGoV5Xd+BFJT9o+PZ/fRsSfa+kKKdx8882l9U2bNpXWZ2Zm+l52RL4jyr7DHhFHJH2pxl4ANIhLb0AShB1IgrADSRB2IAnCDiTBT1zRmiuvvLK0fv755w+okxzYsgNJEHYgCcIOJEHYgSQIO5AEYQeSIOxAElxnR6NWrVrVtXbbbbdVmvehQ4dK6zfddFPX2tTUVKVln43YsgNJEHYgCcIOJEHYgSQIO5AEYQeSIOxAElxnRyWjo6Ol9S1btnStXXTRRZWWfd9995XWjx07Vmn+5xq27EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBNfZUcnGjRtL65dffnnf83766adL69u3b+973hn13LLbfsz2tO2Ds6ZdYvsp268Vj4uabRNAVfPZjd8qac0Z0+6UtDsirpK0u3gNYIj1DHtEPCvp7TMmr5W0rXi+TdK6mvsCULN+j9lHIuJE8fxNSSPd3mh7TNJYn8sBUJPKJ+giImxHSX1c0rgklb0PQLP6vfQ2ZXuJJBWP0/W1BKAJ/YZ9l6TT11w2StpZTzsAmuKI8j1r249LWilpsaQpST+W9AdJv5f0WUnHJK2PiDNP4s01L3bjzzKLFy8urfe6//rMzEzX2jvvvFP62fXr15fW9+zZU1rPKiI81/Sex+wRsaFL6fpKHQEYKL4uCyRB2IEkCDuQBGEHkiDsQBL8xDW5ZcuWldZ37NjR2LIfeuih0jqX1urFlh1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkuA6e3Jr1px5L9EPu+aaayrNf/fu3V1rDz74YKV54+Nhyw4kQdiBJAg7kARhB5Ig7EAShB1IgrADSfS8lXStC+NW0gO3bl35MHxbt24trS9cuLC0vnfv3tJ62e2ge92GGv3pditptuxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kAS/Zz8HlN37vcn7vkvSkSNHSutcSx8ePbfsth+zPW374Kxp99ietL2/+Lux2TYBVDWf3fitkua6nckvImJ58fenetsCULeeYY+IZyW9PYBeADSoygm6W20fKHbzF3V7k+0x2xO2JyosC0BF/Yb9l5K+IGm5pBOS7u/2xogYj4gVEbGiz2UBqEFfYY+IqYh4PyJmJP1K0nX1tgWgbn2F3faSWS+/Kelgt/cCGA49r7PbflzSSkmLbR+X9GNJK20vlxSSjkq6pcEe0cOmTZu61mZmZhpd9ubNmxudP+rTM+wRsWGOyY820AuABvF1WSAJwg4kQdiBJAg7kARhB5LgJ65ngeXLl5fWV69e3diyd+7cWVo/fPhwY8tGvdiyA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EASDNl8Fpieni6tL1rU9a5gPT333HOl9RtuuKG0fvLkyb6XjWYwZDOQHGEHkiDsQBKEHUiCsANJEHYgCcIOJMHv2c8Cl156aWm9yu2iH3nkkdI619HPHWzZgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJrrMPgS1btpTWFyxo7v/kvXv3NjZvDJee/4psL7W9x/bLtl+y/YNi+iW2n7L9WvHY/x0UADRuPpuM9yT9MCKulvQVSd+3fbWkOyXtjoirJO0uXgMYUj3DHhEnIuKF4vm7kl6RdIWktZK2FW/bJmldU00CqO5jHbPbXibpWkn/lDQSESeK0puSRrp8ZkzSWP8tAqjDvM/82L5A0g5Jt0fEf2fXonPXyjlvJhkR4xGxIiJWVOoUQCXzCrvtT6oT9N9ExBPF5CnbS4r6Eknlt0AF0Kqeu/G2LelRSa9ExAOzSrskbZS0uXgsH9s3sV5DLq9ataq03usnrKdOnepae/jhh0s/OzU1VVrHuWM+x+xflfRtSS/a3l9Mu0udkP/e9nclHZO0vpkWAdShZ9gj4h+S5rzpvKTr620HQFP4uiyQBGEHkiDsQBKEHUiCsANJ8BPXAbj44otL65dddlml+U9OTnat3XHHHZXmjXMHW3YgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1Igt+zD8ChQ4dK672GTR4dHa2zHSTFlh1IgrADSRB2IAnCDiRB2IEkCDuQBGEHknBElL/BXippu6QRSSFpPCIetH2PpO9J+k/x1rsi4k895lW+MACVRcScoy7PJ+xLJC2JiBdsXyjpeUnr1BmP/WRE/Hy+TRB2oHndwj6f8dlPSDpRPH/X9iuSrqi3PQBN+1jH7LaXSbpW0j+LSbfaPmD7MduLunxmzPaE7YlKnQKopOdu/AdvtC+Q9Iykn0bEE7ZHJL2lznH8T9TZ1f9Oj3mwGw80rO9jdkmy/UlJf5T0l4h4YI76Mkl/jIgv9pgPYQca1i3sPXfjbVvSo5JemR304sTdad+UdLBqkwCaM5+z8aOS/i7pRUkzxeS7JG2QtFyd3fijkm4pTuaVzYstO9CwSrvxdSHsQPP63o0HcG4g7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJDHoIZvfknRs1uvFxbRhNKy9DWtfEr31q87eruxWGOjv2T+ycHsiIla01kCJYe1tWPuS6K1fg+qN3XggCcIOJNF22MdbXn6ZYe1tWPuS6K1fA+mt1WN2AIPT9pYdwIAQdiCJVsJue43tw7Zft31nGz10Y/uo7Rdt7297fLpiDL1p2wdnTbvE9lO2Xyse5xxjr6Xe7rE9Way7/bZvbKm3pbb32H7Z9ku2f1BMb3XdlfQ1kPU28GN22+dJelXSNyQdl7RP0oaIeHmgjXRh+6ikFRHR+hcwbH9N0klJ208PrWX7Z5LejojNxX+UiyJi05D0do8+5jDeDfXWbZjxm9Xiuqtz+PN+tLFlv07S6xFxJCJOSfqdpLUt9DH0IuJZSW+fMXmtpG3F823q/GMZuC69DYWIOBERLxTP35V0epjxVtddSV8D0UbYr5D0xqzXxzVc472HpL/aft72WNvNzGFk1jBbb0oaabOZOfQcxnuQzhhmfGjWXT/Dn1fFCbqPGo2IL0u6QdL3i93VoRSdY7Bhunb6S0lfUGcMwBOS7m+zmWKY8R2Sbo+I/86utbnu5uhrIOutjbBPSlo66/VnimlDISImi8dpSU+qc9gxTKZOj6BbPE633M8HImIqIt6PiBlJv1KL664YZnyHpN9ExBPF5NbX3Vx9DWq9tRH2fZKusv0525+S9C1Ju1ro4yNsLyxOnMj2QkmrNXxDUe+StLF4vlHSzhZ7+ZBhGca72zDjanndtT78eUQM/E/Sjeqckf+3pB+10UOXvj4v6V/F30tt9ybpcXV26/6nzrmN70q6VNJuSa9J+pukS4aot1+rM7T3AXWCtaSl3kbV2UU/IGl/8Xdj2+uupK+BrDe+LgskwQk6IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUji/5/q50l6GREBAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAMbklEQVR4nO3db4gc9R3H8c8n1iJE0WjoGTU1bfFJKTaWIIUeJcU0RBGSPgnNgxKp9PqgSgsVIlaoUgqhVouIClc0f4pVhGgTSmlrQ9SWoHhKqlGTakOCOeJdRaTmUar37YOdyBlvZ8+dmZ1Nvu8XHLs7392ZL0M+mX+783NECMCZb0HbDQAYDMIOJEHYgSQIO5AEYQeS+MwgF2abU/9AwyLCc02vtGW3vcb2Qdtv2r61yrwANMv9Xme3fZakf0n6tqSjkl6QtCEiXiv5DFt2oGFNbNmvlvRmRByKiBOSHpO0tsL8ADSoStgvlfTWrNdHi2kfY3vM9oTtiQrLAlBR4yfoImJc0rjEbjzQpipb9klJS2e9vqyYBmAIVQn7C5KusP0F25+V9F1Ju+ppC0Dd+t6Nj4gPbN8k6S+SzpL0cES8WltnAGrV96W3vhbGMTvQuEa+VAPg9EHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEn0P2Qw07fbbby+t33nnnaX1BQu6b8tWrlxZ+tlnnnmmtH46qhR224clvS/pQ0kfRMSKOpoCUL86tuzfioh3apgPgAZxzA4kUTXsIemvtl+0PTbXG2yP2Z6wPVFxWQAqqLobPxoRk7Y/J+kp2wci4tnZb4iIcUnjkmQ7Ki4PQJ8qbdkjYrJ4nJb0pKSr62gKQP36DrvthbbPO/lc0mpJ++tqDEC9quzGj0h60vbJ+fw+Iv5cS1dI4YYbbiitb9q0qbQ+MzPT97Ij8h1R9h32iDgk6as19gKgQVx6A5Ig7EAShB1IgrADSRB2IAl+4orWXH755aX1c845Z0Cd5MCWHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeS4Do7GrVq1aqutZtvvrnSvA8cOFBav/7667vWpqamKi37dMSWHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeS4Do7KhkdHS2tb9mypWvt/PPPr7Tsu+66q7R+5MiRSvM/07BlB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkuM6OSjZu3Fhav+SSS/qe99NPP11a3759e9/zzqjnlt32w7anbe+fNe1C20/ZfqN4XNRsmwCqms9u/FZJa06Zdquk3RFxhaTdxWsAQ6xn2CPiWUnvnjJ5raRtxfNtktbV2xaAuvV7zD4SEceK529LGun2Rttjksb6XA6AmlQ+QRcRYTtK6uOSxiWp7H0AmtXvpbcp20skqXicrq8lAE3oN+y7JJ285rJR0s562gHQFEeU71nbflTSSkmLJU1J+rmkP0h6XNLnJR2RtD4iTj2JN9e82I0/zSxevLi03uv+6zMzM11r7733Xuln169fX1rfs2dPaT2riPBc03ses0fEhi6layp1BGCg+LoskARhB5Ig7EAShB1IgrADSfAT1+SWLVtWWt+xY0djy77vvvtK61xaqxdbdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1Iguvsya1Zc+q9RD/uyiuvrDT/3bt3d63de++9leaNT4ctO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4k0fNW0rUujFtJD9y6detK61u3bi2tL1y4sLS+d+/e0nrZ7aB73YYa/el2K2m27EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBL9nPwOU3fu9yfu+S9KhQ4dK61xLHx49t+y2H7Y9bXv/rGl32J60va/4u67ZNgFUNZ/d+K2S5rqdyW8iYnnx96d62wJQt55hj4hnJb07gF4ANKjKCbqbbL9c7OYv6vYm22O2J2xPVFgWgIr6DfuDkr4kabmkY5Lu7vbGiBiPiBURsaLPZQGoQV9hj4ipiPgwImYk/VbS1fW2BaBufYXd9pJZL78jaX+39wIYDj2vs9t+VNJKSYttH5X0c0krbS+XFJIOS/phcy2il02bNnWtzczMNLrszZs3Nzp/1Kdn2CNiwxyTH2qgFwAN4uuyQBKEHUiCsANJEHYgCcIOJMFPXE8Dy5cvL62vXr26sWXv3LmztH7w4MHGlo16sWUHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQYsvk0MD09XVpftKjrXcF6eu6550rr1157bWn9+PHjfS8bzWDIZiA5wg4kQdiBJAg7kARhB5Ig7EAShB1Igt+znwYuuuii0nqV20U/8MADpXWuo5852LIDSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBJcZx8CW7ZsKa0vWNDc/8l79+5tbN4YLj3/FdleanuP7ddsv2r7x8X0C20/ZfuN4rH/OygAaNx8NhkfSPppRHxZ0tcl/cj2lyXdKml3RFwhaXfxGsCQ6hn2iDgWES8Vz9+X9LqkSyWtlbSteNs2Sesa6hFADT7VMbvtZZKukvS8pJGIOFaU3pY00uUzY5LGKvQIoAbzPvNj+1xJOyT9JCL+O7sWnbtWznkzyYgYj4gVEbGiUqcAKplX2G2frU7QH4mIJ4rJU7aXFPUlkspvgQqgVT13421b0kOSXo+Ie2aVdknaKGlz8Vg+tm9ivYZcXrVqVWm9109YT5w40bV2//33l352amqqtI4zx3yO2b8h6XuSXrG9r5h2mzohf9z2jZKOSFrfSIcAatEz7BHxD0lz3nRe0jX1tgOgKXxdFkiCsANJEHYgCcIOJEHYgST4iesAXHDBBaX1iy++uNL8Jycnu9ZuueWWSvPGmYMtO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiTB79kH4MCBA6X1XsMmj46O1tkOkmLLDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJOCLK32AvlbRd0oikkDQeEffavkPSDyT9p3jrbRHxpx7zKl8YgMoiYs5Rl+cT9iWSlkTES7bPk/SipHXqjMd+PCJ+Pd8mCDvQvG5hn8/47MckHSuev2/7dUmX1tsegKZ9qmN228skXSXp+WLSTbZftv2w7UVdPjNme8L2RLVWAVTRczf+ozfa50p6RtIvI+IJ2yOS3lHnOP4X6uzqf7/HPNiNBxrW9zG7JNk+W9IfJf0lIu6Zo75M0h8j4is95kPYgYZ1C3vP3XjblvSQpNdnB704cXfSdyTtr9okgObM52z8qKS/S3pF0kwx+TZJGyQtV2c3/rCkHxYn88rmxZYdaFil3fi6EHageX3vxgM4MxB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSGPSQze9IOjLr9eJi2jAa1t6GtS+J3vpVZ2+XdysM9Pfsn1i4PRERK1proMSw9jasfUn01q9B9cZuPJAEYQeSaDvs4y0vv8yw9jasfUn01q+B9NbqMTuAwWl7yw5gQAg7kEQrYbe9xvZB22/avrWNHrqxfdj2K7b3tT0+XTGG3rTt/bOmXWj7KdtvFI9zjrHXUm932J4s1t0+29e11NtS23tsv2b7Vds/Lqa3uu5K+hrIehv4MbvtsyT9S9K3JR2V9IKkDRHx2kAb6cL2YUkrIqL1L2DY/qak45K2nxxay/avJL0bEZuL/ygXRcSmIentDn3KYbwb6q3bMOM3qMV1V+fw5/1oY8t+taQ3I+JQRJyQ9JiktS30MfQi4llJ754yea2kbcXzber8Yxm4Lr0NhYg4FhEvFc/fl3RymPFW111JXwPRRtgvlfTWrNdHNVzjvYekv9p+0fZY283MYWTWMFtvSxpps5k59BzGe5BOGWZ8aNZdP8OfV8UJuk8ajYivSbpW0o+K3dWhFJ1jsGG6dvqgpC+pMwbgMUl3t9lMMcz4Dkk/iYj/zq61ue7m6Gsg662NsE9KWjrr9WXFtKEQEZPF47SkJ9U57BgmUydH0C0ep1vu5yMRMRURH0bEjKTfqsV1VwwzvkPSIxHxRDG59XU3V1+DWm9thP0FSVfY/oLtz0r6rqRdLfTxCbYXFidOZHuhpNUavqGod0naWDzfKGlni718zLAM491tmHG1vO5aH/48Igb+J+k6dc7I/1vSz9rooUtfX5T0z+Lv1bZ7k/SoOrt1/1Pn3MaNki6StFvSG5L+JunCIertd+oM7f2yOsFa0lJvo+rsor8saV/xd13b666kr4GsN74uCyTBCTogCcIOJEHYgSQIO5AEYQeSIOxAEoQdSOL/n+rnSfOvm60AAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -463,7 +675,7 @@
     }
    ],
    "source": [
-    "plt.imshow(images[3], cmap='gray', interpolation='none')"
+    "plt.imshow(images[3, 0], cmap='gray', interpolation='none')"
    ]
   },
   {
@@ -475,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -498,7 +710,7 @@
        "0.8799999952316284"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -523,7 +735,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,13 +750,13 @@
     "        self.fc2 = crypten.nn.Linear(128, 10)\n",
     "\n",
     "    def forward(self, x):\n",
-    "        x = x.unsqueeze(1)\n",
     "        x = self.conv1(x)\n",
     "        x = x.relu()\n",
     "        x = self.conv2(x)\n",
     "        x = x.relu()\n",
     "        x = x.max_pool2d(2)\n",
     "        x = self.dropout1(x)\n",
+    "        x = x.flatten(start_dim=1)\n",
     "        x = self.fc1(x)\n",
     "        x = x.relu()\n",
     "        x = self.dropout2(x)\n",
@@ -554,7 +766,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,45 +775,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "torch.Size([1, 28, 28])\n"
+      "torch.Size([100, 1, 28, 28])\n",
+      "torch.Size([1, 1, 28, 28])\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<crypten.autograd_cryptensor.AutogradCrypTensor object at 0x131944990>"
+       "MPCTensor(\n",
+       "\t_tensor=tensor([[ 2551,  4465,  1717, -1723,   966, -7681,   494,  -457,   411,  3919]])\n",
+       "\tplain_text=HIDDEN\n",
+       "\tptype=ptype.arithmetic\n",
+       ")"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "x = images_enc[0].unsqueeze(0)\n",
+    "print(images_enc.size())\n",
+    "x = images_enc[0].view(1, 1, 28, 28)\n",
     "print(x.shape)\n",
     "model(x)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "epoch 0 loss: 2.3135986328125\n",
-      "epoch 1 loss: 2.2531890869140625\n",
-      "epoch 2 loss: 2.1912384033203125\n"
+      "epoch 0 loss: 2.272796630859375\n",
+      "epoch 1 loss: 2.2662353515625\n",
+      "epoch 2 loss: 2.2158050537109375\n"
      ]
     }
    ],
@@ -611,7 +829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +845,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -640,13 +858,12 @@
     "        super().__init__()\n",
     "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
     "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
-    "        self.dropout1 = nn.Dropout2d(0.25)\n",
-    "        self.dropout2 = nn.Dropout2d(0.5)\n",
+    "        self.dropout1 = nn.Dropout(0.5)\n",
+    "        self.dropout2 = nn.Dropout(0.5)\n",
     "        self.fc1 = nn.Linear(9216, 128)\n",
     "        self.fc2 = nn.Linear(128, 10)\n",
     "\n",
     "    def forward(self, x):\n",
-    "        x = x.unsqueeze(1)\n",
     "        x = self.conv1(x)\n",
     "        x = F.relu(x)\n",
     "        x = self.conv2(x)\n",
@@ -664,7 +881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,16 +890,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/brianknott/Desktop/CrypTen/crypten/nn/onnx_converter.py:161: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /Users/distiller/project/conda/conda-bld/pytorch_1616554799287/work/torch/csrc/utils/tensor_numpy.cpp:143.)\n",
+      "  param = torch.from_numpy(numpy_helper.to_array(node))\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "<crypten.nn.module.Graph at 0x128d876d0>"
+       "Graph encrypted module"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -695,14 +920,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<crypten.autograd_cryptensor.AutogradCrypTensor object at 0x131b7f410>\n"
+      "MPCTensor(\n",
+      "\t_tensor=tensor([[-156495, -149670, -157653, -148411, -152466, -145310, -148855, -147026,\n",
+      "         -149449, -149893]])\n",
+      "\tplain_text=HIDDEN\n",
+      "\tptype=ptype.arithmetic\n",
+      ")\n"
      ]
     }
    ],
@@ -713,15 +943,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tensor([[-2.2325, -2.2288, -2.2988, -2.3620, -2.2741, -2.2421, -2.4341, -2.2122,\n",
-      "         -2.2984, -2.3620]])\n"
+      "tensor([[-2.3879, -2.2838, -2.4056, -2.2646, -2.3264, -2.2173, -2.2713, -2.2434,\n",
+      "         -2.2804, -2.2872]])\n"
      ]
     }
    ],
@@ -731,16 +961,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor(7)"
+       "tensor(5)"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -751,36 +981,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "epoch 0 loss: 2.3262786865234375\n",
-      "epoch 1 loss: 2.287811279296875\n",
-      "epoch 2 loss: 2.182342529296875\n"
+      "epoch 0 loss: 2.3539276123046875\n",
+      "epoch 1 loss: 2.28973388671875\n",
+      "epoch 2 loss: 2.2553558349609375\n"
      ]
     }
    ],
    "source": [
     "crypten_model = train_model(crypten_model, images_enc[:10, ], labels_enc[:10,], epochs=3)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "crypten-pycon",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "crypten-pycon"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -792,7 +1015,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Summary:
Per https://github.com/facebookresearch/CrypTen/issues/272

Fixed issues with ipynb 2 in pycon-workshop-2020.

Note: ONNX exporter was breaking with input `nn.Dropout2d` with

```
RuntimeError: No Op registered for DropoutNd with domain_version of 9

==> Context: Bad node spec: input: "13" output: "14" output: "15" name: "DropoutNd_5" op_type: "DropoutNd" attribute { name: "ratio" f: 0.5 type: FLOAT }
```

Fixed by swapping to `nn.Dropout`

Differential Revision: D28797586

