### PR TITLE
Fix 3PC division protocol

### DIFF
--- a/crypten/encoder.py
+++ b/crypten/encoder.py
@@ -24,7 +24,7 @@ def nearest_integer_division(tensor, integer):
     pos_remainder = (1 - lez) * tensor % integer
     neg_remainder = lez * ((integer - tensor) % integer)
     remainder = pos_remainder + neg_remainder
-    quotient = tensor // integer
+    quotient = tensor.div(integer, rounding_mode="floor")
     correction = (2 * remainder > integer).long()
     return quotient + tensor.sign() * correction
 
@@ -72,7 +72,7 @@ class FixedPointEncoder:
         assert is_int_tensor(tensor), "input must be a LongTensor"
         if self._scale > 1:
             correction = (tensor < 0).long()
-            dividend = tensor // self._scale - correction
+            dividend = tensor.div(self._scale - correction, rounding_mode="floor")
             remainder = tensor % self._scale
             remainder += (remainder == 0).long() * self._scale * correction
 

--- a/crypten/mpc/primitives/beaver.py
+++ b/crypten/mpc/primitives/beaver.py
@@ -163,7 +163,8 @@ def truncate(x, y):
     # NOTE: The multiplication here must be split into two parts
     # to avoid long out-of-bounds when y <= 2 since (2 ** 63) is
     # larger than the largest long integer.
-    x -= wrap_count * 4 * (int(2 ** 62) // y)
+    correction = wrap_count * 4 * (int(2 ** 62) // y)
+    x.share -= correction.share
     return x
 
 

--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -2100,6 +2100,11 @@ class TestTTP(MultiProcessTestCase, TestMPC):
         super(TestTTP, self).tearDown()
 
 
+class Test3PC(MultiProcessTestCase, TestMPC):
+    def setUp(self):
+        super(Test3PC, self).setUp(world_size=3)
+
+
 class TestRSS(MultiProcessTestCase, TestMPC):
     def setUp(self):
         self._original_protocol = cfg.mpc.protocol


### PR DESCRIPTION
Summary:
Fixes bug described in https://github.com/facebookresearch/CrypTen/issues/308

This bug causes wrap-around errors in 3+ party division. Upon inspection, it became clear that this bug is caused by a change in the scaling logic introduced in D29064976 (https://github.com/facebookresearch/CrypTen/commit/a632bf4a5cc323f4d4bc42b1ca4286ff29752f9f).

This bug happened because the correction applied to wraps has different scaling than the input tensor, and the new logic rescales accordingly. This can be fixed by applying the arithmetic on the shares rather than the ASTs.

To ensure bugs like this won't be reproduced again, I've introduced 3PC tests into test_mpc.py as well. These will increase runtime of the test harness, making it more necessary to upgrade the testing framework for easier submissions.

Differential Revision: D31206649

