### PR TITLE
Create cache for async tuple generation

### DIFF
--- a/crypten/__init__.py
+++ b/crypten/__init__.py
@@ -542,6 +542,19 @@ def log(*args, in_order=False, dst=0, **kwargs):
     )
 
 
+# TupleProvider tracing functions
+def trace(tracing=True):
+    crypten.mpc.get_default_provider().trace(tracing=tracing)
+
+
+def trace_once():
+    crypten.mpc.get_default_provider().trace_once()
+
+
+def fill_cache():
+    crypten.mpc.get_default_provider().fill_cache()
+
+
 # expose classes and functions in package:
 __all__ = [
     "CrypTensor",
@@ -549,6 +562,7 @@ __all__ = [
     "enable_grad",
     "set_grad_enabled",
     "debug",
+    "fill_cache",
     "generators",
     "init",
     "init_thread",
@@ -556,5 +570,7 @@ __all__ = [
     "mpc",
     "nn",
     "print",
+    "trace",
+    "trace_once",
     "uninit",
 ]

--- a/crypten/mpc/__init__.py
+++ b/crypten/mpc/__init__.py
@@ -28,9 +28,9 @@ binary = ptype.binary
 
 # Set provider
 __SUPPORTED_PROVIDERS = {
-    "TFP": provider.TrustedFirstParty,
-    "TTP": provider.TrustedThirdParty,
-    "HE": provider.HomomorphicProvider,
+    "TFP": provider.TrustedFirstParty(),
+    "TTP": provider.TrustedThirdParty(),
+    "HE": provider.HomomorphicProvider(),
 }
 
 

--- a/crypten/mpc/provider/homomorphic_provider.py
+++ b/crypten/mpc/provider/homomorphic_provider.py
@@ -5,31 +5,28 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .provider import TupleProvider
 
-class HomomorphicProvider:
+
+class HomomorphicProvider(TupleProvider):
     NAME = "HE"
 
-    @staticmethod
-    def generate_additive_triple(size0, size1, op, *args, **kwargs):
+    def generate_additive_triple(self, size0, size1, op, *args, **kwargs):
         """Generate multiplicative triples of given sizes"""
         raise NotImplementedError("HomomorphicProvider not implemented")
 
-    @staticmethod
-    def square(size):
+    def square(self, size):
         """Generate square double of given size"""
         raise NotImplementedError("HomomorphicProvider not implemented")
 
-    @staticmethod
-    def generate_xor_triple(size0, size1):
+    def generate_xor_triple(self, size0, size1):
         """Generate xor triples of given size"""
         raise NotImplementedError("HomomorphicProvider not implemented")
 
-    @staticmethod
-    def wrap_rng(size, num_parties):
+    def wrap_rng(self, size, num_parties):
         """Generate random shared tensor of given size and sharing of its wraps"""
         raise NotImplementedError("HomomorphicProvider not implemented")
 
-    @staticmethod
-    def B2A_rng(size):
+    def B2A_rng(self, size):
         """Generate random bit tensor as arithmetic and binary shared tensors"""
         raise NotImplementedError("HomomorphicProvider not implemented")

--- a/crypten/mpc/provider/provider.py
+++ b/crypten/mpc/provider/provider.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class TupleProvider:
+    TRACEABLE_FUNCTIONS = [
+        "generate_additive_triple",
+        "square",
+        "generate_binary_triple",
+        "wrap_rng",
+        "B2A_rng",
+    ]
+
+    def __init__(self):
+        self.tracing = False
+        self.request_cache = []
+        self.tuple_cache = {}
+
+    def trace(self, tracing=True):
+        self.tracing = tracing
+
+    def trace_once(self):
+        untraced = self.request_cache.empty()
+        self.trace(tracing=untraced)
+
+    def __getattribute__(self, func_name):
+        if func_name not in TupleProvider.TRACEABLE_FUNCTIONS:
+            return object.__getattribute__(self, func_name)
+
+        # Trace requests while tracing
+        if self.tracing:
+
+            def func_with_trace(*args, **kwargs):
+                request = (func_name, args, kwargs)
+                self.request_cache.append(request)
+                return object.__getattribute__(self, func_name)(*args, **kwargs)
+
+            return func_with_trace
+
+        # If the cache is empty, call function directly
+        if len(self.tuple_cache) == 0:
+            return object.__getattribute__(self, func_name)
+
+        # Return results from cache if available
+        def func_from_cache(*args, **kwargs):
+            hashable_kwargs = frozenset(kwargs.items())
+            request = (func_name, args, hashable_kwargs)
+            # Read from cache
+            if request in self.tuple_cache.keys():
+                return self.tuple_cache[request].pop()
+            # Cache miss
+            return object.__getattribute__(self, func_name)(*args, **kwargs)
+
+        return func_from_cache
+
+    def fill_cache(self):
+        # TODO: parallelize / async this
+        for request in self.request_cache:
+            func_name, args, kwargs = request
+            result = object.__getattribute__(self, func_name)(*args, **kwargs)
+
+            hashable_kwargs = frozenset(kwargs.items())
+            hashable_request = (func_name, args, hashable_kwargs)
+            if hashable_request in self.tuple_cache.keys():
+                self.tuple_cache[hashable_request].append(result)
+            else:
+                self.tuple_cache[hashable_request] = [result]
+
+    def generate_additive_triple(self, size0, size1, op, device=None, *args, **kwargs):
+        """Generate multiplicative triples of given sizes"""
+        raise NotImplementedError(
+            "TupleProvider generate_additive_triple not implemented."
+        )
+
+    def square(self, size, device=None):
+        """Generate square double of given size"""
+        raise NotImplementedError("TupleProvider square not implemented.")
+
+    def generate_binary_triple(self, size0, size1, device=None):
+        """Generate xor triples of given size"""
+        raise NotImplementedError(
+            "TupleProvider generate_binary_triple not implemented."
+        )
+
+    def wrap_rng(self, size, device=None):
+        """Generate random shared tensor of given size and sharing of its wraps"""
+        raise NotImplementedError("TupleProvider wrap_rng not implemented.")
+
+    def B2A_rng(self, size, device=None):
+        """Generate random bit tensor as arithmetic and binary shared tensors"""
+        raise NotImplementedError("TupleProvider B2A_rng not implemented.")

--- a/crypten/mpc/provider/tfp_provider.py
+++ b/crypten/mpc/provider/tfp_provider.py
@@ -11,12 +11,13 @@ from crypten.common.rng import generate_kbit_random_tensor, generate_random_ring
 from crypten.common.util import count_wraps, torch_stack
 from crypten.mpc.primitives import ArithmeticSharedTensor, BinarySharedTensor
 
+from .provider import TupleProvider
 
-class TrustedFirstParty:
+
+class TrustedFirstParty(TupleProvider):
     NAME = "TFP"
 
-    @staticmethod
-    def generate_additive_triple(size0, size1, op, device=None, *args, **kwargs):
+    def generate_additive_triple(self, size0, size1, op, device=None, *args, **kwargs):
         """Generate multiplicative triples of given sizes"""
         a = generate_random_ring_element(size0, device=device)
         b = generate_random_ring_element(size1, device=device)
@@ -29,8 +30,7 @@ class TrustedFirstParty:
 
         return a, b, c
 
-    @staticmethod
-    def square(size, device=None):
+    def square(self, size, device=None):
         """Generate square double of given size"""
         r = generate_random_ring_element(size, device=device)
         r2 = r.mul(r)
@@ -40,8 +40,7 @@ class TrustedFirstParty:
         stacked = ArithmeticSharedTensor(stacked, precision=0, src=0)
         return stacked[0], stacked[1]
 
-    @staticmethod
-    def generate_binary_triple(size0, size1, device=None):
+    def generate_binary_triple(self, size0, size1, device=None):
         """Generate xor triples of given size"""
         a = generate_kbit_random_tensor(size0, device=device)
         b = generate_kbit_random_tensor(size1, device=device)
@@ -53,8 +52,7 @@ class TrustedFirstParty:
 
         return a, b, c
 
-    @staticmethod
-    def wrap_rng(size, device=None):
+    def wrap_rng(self, size, device=None):
         """Generate random shared tensor of given size and sharing of its wraps"""
         num_parties = comm.get().get_world_size()
         r = [
@@ -69,8 +67,7 @@ class TrustedFirstParty:
 
         return r, theta_r
 
-    @staticmethod
-    def B2A_rng(size, device=None):
+    def B2A_rng(self, size, device=None):
         """Generate random bit tensor as arithmetic and binary shared tensors"""
         # generate random bit
         r = generate_kbit_random_tensor(size, bitlength=1, device=device)

--- a/crypten/mpc/provider/ttp_provider.py
+++ b/crypten/mpc/provider/ttp_provider.py
@@ -15,15 +15,16 @@ from crypten.common.rng import generate_kbit_random_tensor, generate_random_ring
 from crypten.common.util import count_wraps
 from crypten.mpc.primitives import ArithmeticSharedTensor, BinarySharedTensor
 
+from .provider import TupleProvider
+
 
 TTP_FUNCTIONS = ["additive", "square", "binary", "wraps", "B2A"]
 
 
-class TrustedThirdParty:
+class TrustedThirdParty(TupleProvider):
     NAME = "TTP"
 
-    @staticmethod
-    def generate_additive_triple(size0, size1, op, device=None, *args, **kwargs):
+    def generate_additive_triple(self, size0, size1, op, device=None, *args, **kwargs):
         """Generate multiplicative triples of given sizes"""
         generator = TTPClient.get().get_generator(device=device)
 
@@ -45,8 +46,7 @@ class TrustedThirdParty:
 
         return a, b, c
 
-    @staticmethod
-    def square(size, device=None):
+    def square(self, size, device=None):
         """Generate square double of given size"""
         generator = TTPClient.get().get_generator(device=device)
 
@@ -61,8 +61,7 @@ class TrustedThirdParty:
         r2 = ArithmeticSharedTensor.from_shares(r2, precision=0)
         return r, r2
 
-    @staticmethod
-    def generate_binary_triple(size0, size1, device=None):
+    def generate_binary_triple(self, size0, size1, device=None):
         """Generate binary triples of given size"""
         generator = TTPClient.get().get_generator(device=device)
 
@@ -82,8 +81,7 @@ class TrustedThirdParty:
         c = BinarySharedTensor.from_shares(c)
         return a, b, c
 
-    @staticmethod
-    def wrap_rng(size, device=None):
+    def wrap_rng(self, size, device=None):
         """Generate random shared tensor of given size and sharing of its wraps"""
         generator = TTPClient.get().get_generator(device=device)
 
@@ -100,8 +98,7 @@ class TrustedThirdParty:
         theta_r = ArithmeticSharedTensor.from_shares(theta_r, precision=0)
         return r, theta_r
 
-    @staticmethod
-    def B2A_rng(size, device=None):
+    def B2A_rng(self, size, device=None):
         """Generate random bit tensor as arithmetic and binary shared tensors"""
         generator = TTPClient.get().get_generator(device=device)
 
@@ -119,28 +116,6 @@ class TrustedThirdParty:
         rA = ArithmeticSharedTensor.from_shares(rA, precision=0)
         rB = BinarySharedTensor.from_shares(rB)
         return rA, rB
-
-    @staticmethod
-    def rand(*sizes, encoder=None, device=None):
-        """Generate random ArithmeticSharedTensor uniform on [0, 1]"""
-        generator = TTPClient.get().get_generator(device=device)
-
-        if isinstance(sizes, torch.Size):
-            sizes = tuple(sizes)
-
-        if isinstance(sizes[0], torch.Size):
-            sizes = tuple(sizes[0])
-
-        if comm.get().get_rank() == 0:
-            # Request samples from TTP
-            samples = TTPClient.get().ttp_request(
-                "rand", device, *sizes, encoder=encoder
-            )
-        else:
-            samples = generate_random_ring_element(
-                sizes, generator=generator, device=device
-            )
-        return ArithmeticSharedTensor.from_shares(samples)
 
     @staticmethod
     def _init():


### PR DESCRIPTION
Summary:
Creates a caching system for storing pre-processed tuples. In order to use for Offline Tuple Generation, the following is required:

- Implement saving tuple cache to file and/or
- Asynchronous / parallelized tuple generation (i.e. in separate threads / processes)

Implementation works for all tuple providers and implements an abstract class for generic tuple-generation protocols.

Note: Also addresses https://github.com/facebookresearch/CrypTen/issues/175

Differential Revision: D32283362

