### PR TITLE
Remove pytest-runner dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ if __name__ == "__main__":
         url="https://github.com/facebookresearch/CrypTen",
         author=AUTHOR,
         license=LICENSE,
-        setup_requires=["pytest-runner"],
         tests_require=["pytest"],
         data_files=[("/configs", ["configs/default.yaml"])],
     )


### PR DESCRIPTION
Summary:
Removes pytest-runner in setup.py since it is deprecated here: https://pypi.org/project/pytest-runner/

This has caused issues for some OSS users.

Differential Revision: D35153940

