### PR TITLE
Enable customization of party performing public computations

### DIFF
--- a/crypten/mpc/primitives/arithmetic.py
+++ b/crypten/mpc/primitives/arithmetic.py
@@ -34,6 +34,8 @@ class ArithmeticSharedTensor(object):
     the number of parties present in the protocol (world_size).
     """
 
+    PUBLIC_COMPUTE_PARTY = 0  # Party responsible for public addition.
+
     # constructors:
     def __init__(
         self,
@@ -239,7 +241,7 @@ class ArithmeticSharedTensor(object):
         result = self.shallow_copy()
         if isinstance(value, (int, float)):
             value = self.encoder.encode(value).item()
-            if result.rank == 0:
+            if result.rank == self.PUBLIC_COMPUTE_PARTY:
                 result.share = torch.nn.functional.pad(
                     result.share, pad, mode=mode, value=value
                 )
@@ -362,7 +364,7 @@ class ArithmeticSharedTensor(object):
             y = result.encoder.encode(y, device=self.device)
 
             if additive_func:  # ['add', 'sub']
-                if result.rank == 0:
+                if result.rank == self.PUBLIC_COMPUTE_PARTY:
                     result.share = getattr(result.share, op)(y)
                 else:
                     result.share = torch.broadcast_tensors(result.share, y)[0]
@@ -514,7 +516,7 @@ class ArithmeticSharedTensor(object):
         private = isinstance(tensor, ArithmeticSharedTensor)
         if public:
             enc_tensor = self.encoder.encode(tensor)
-            if self.rank == 0:
+            if self.rank == self.PUBLIC_COMPUTE_PARTY:
                 self._tensor.index_add_(dim, index, enc_tensor)
         elif private:
             self._tensor.index_add_(dim, index, tensor._tensor)
@@ -541,7 +543,7 @@ class ArithmeticSharedTensor(object):
         public = isinstance(other, (int, float)) or is_tensor(other)
         private = isinstance(other, ArithmeticSharedTensor)
         if public:
-            if self.rank == 0:
+            if self.rank == self.PUBLIC_COMPUTE_PARTY:
                 self.share.scatter_add_(dim, index, self.encoder.encode(other))
         elif private:
             self.share.scatter_add_(dim, index, other.share)

--- a/crypten/mpc/primitives/binary.py
+++ b/crypten/mpc/primitives/binary.py
@@ -32,6 +32,8 @@ class BinarySharedTensor(object):
     where n is the number of parties present in the protocol (world_size).
     """
 
+    PUBLIC_COMPUTE_PARTY = 0  # Party responsible for public XOR and NOT.
+
     def __init__(
         self, tensor=None, size=None, broadcast_size=False, src=0, device=None
     ):
@@ -214,7 +216,7 @@ class BinarySharedTensor(object):
     def __ixor__(self, y):
         """Bitwise XOR operator (element-wise) in place"""
         if is_tensor(y) or isinstance(y, int):
-            if self.rank == 0:
+            if self.rank == self.PUBLIC_COMPUTE_PARTY:
                 self.share ^= y
         elif isinstance(y, BinarySharedTensor):
             self.share ^= y.share
@@ -267,7 +269,7 @@ class BinarySharedTensor(object):
     def __invert__(self):
         """Bitwise NOT operator (element-wise)"""
         result = self.clone()
-        if result.rank == 0:
+        if result.rank == self.PUBLIC_COMPUTE_PARTY:
             result.share ^= -1
         return result
 

--- a/crypten/mpc/provider/ttp_provider.py
+++ b/crypten/mpc/provider/ttp_provider.py
@@ -23,6 +23,7 @@ TTP_FUNCTIONS = ["additive", "square", "binary", "wraps", "B2A"]
 
 class TrustedThirdParty(TupleProvider):
     NAME = "TTP"
+    COMMUNICATING_PARTY = 0
 
     def generate_additive_triple(self, size0, size1, op, device=None, *args, **kwargs):
         """Generate multiplicative triples of given sizes"""
@@ -30,7 +31,7 @@ class TrustedThirdParty(TupleProvider):
 
         a = generate_random_ring_element(size0, generator=generator, device=device)
         b = generate_random_ring_element(size1, generator=generator, device=device)
-        if comm.get().get_rank() == 0:
+        if comm.get().get_rank() == self.COMMUNICATING_PARTY:
             # Request c from TTP
             c = TTPClient.get().ttp_request(
                 "additive", device, size0, size1, op, *args, **kwargs
@@ -51,7 +52,7 @@ class TrustedThirdParty(TupleProvider):
         generator = TTPClient.get().get_generator(device=device)
 
         r = generate_random_ring_element(size, generator=generator, device=device)
-        if comm.get().get_rank() == 0:
+        if comm.get().get_rank() == self.COMMUNICATING_PARTY:
             # Request r2 from TTP
             r2 = TTPClient.get().ttp_request("square", device, size)
         else:
@@ -68,7 +69,7 @@ class TrustedThirdParty(TupleProvider):
         a = generate_kbit_random_tensor(size0, generator=generator, device=device)
         b = generate_kbit_random_tensor(size1, generator=generator, device=device)
 
-        if comm.get().get_rank() == 0:
+        if comm.get().get_rank() == self.COMMUNICATING_PARTY:
             # Request c from TTP
             c = TTPClient.get().ttp_request("binary", device, size0, size1)
         else:
@@ -86,7 +87,7 @@ class TrustedThirdParty(TupleProvider):
         generator = TTPClient.get().get_generator(device=device)
 
         r = generate_random_ring_element(size, generator=generator, device=device)
-        if comm.get().get_rank() == 0:
+        if comm.get().get_rank() == self.COMMUNICATING_PARTY:
             # Request theta_r from TTP
             theta_r = TTPClient.get().ttp_request("wraps", device, size)
         else:
@@ -107,7 +108,7 @@ class TrustedThirdParty(TupleProvider):
             size, bitlength=1, generator=generator, device=device
         )
 
-        if comm.get().get_rank() == 0:
+        if comm.get().get_rank() == self.COMMUNICATING_PARTY:
             # Request rA from TTP
             rA = TTPClient.get().ttp_request("B2A", device, size)
         else:
@@ -167,8 +168,8 @@ class TTPClient:
 
         def ttp_request(self, func_name, device, *args, **kwargs):
             assert (
-                comm.get().get_rank() == 0
-            ), "Only party 0 communicates with the TTPServer"
+                comm.get().get_rank() == self.COMMUNICATING_PARTY
+            ), f"Only party {self.COMMUNICATING_PARTY} communicates with the TTPServer"
             if device is not None:
                 device = str(device)
             message = {


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

The current implementation of CrypTen's MPC protocol assumes that there is always a party with rank 0. This party is hardcoded to be responsible for performing public addition, public XOR, NOT, and for requesting Beaver triples. In setups in which party 0 exists but does not partake in the computations (that is, is not in `DistributedCommunicator.main_group`) incorrect results will be produced..

This PR introduces class variables that allow a user to customize which party is in charge of those things.

## How Has This Been Tested (if it applies)

Unit tests for public addition, public XOR, and NOT included. There are no unit tests for TTP and TFP, but I have tested the changes locally.

## Checklist

- [ X ] The documentation is up-to-date with the changes I made.
- [ X ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ X ] All tests passed, and additional code has been covered with new tests.
