### PR TITLE
Setup 438

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           no_output_timeout: 3h
           command: |
             . ~/crypten-test/bin/activate
-            echo 'for i in $(ls test/test_*.py | grep -Ev "test_(context|benchmark|tensorboard|models|cuda)"); do python3 -m unittest $i; (($? != 0)) && exit 1; done; exit 0' > run_tests.sh
+            echo 'for i in $(ls test/test_*.py | grep -Ev "test_(context|benchmark|models)"); do python3 -m unittest $i; (($? != 0)) && exit 1; done; exit 0' > run_tests.sh
             bash ./run_tests.sh
       - run:
           name: Linear svm example

--- a/crypten/common/serial.py
+++ b/crypten/common/serial.py
@@ -88,10 +88,10 @@ class RestrictedUnpickler(pickle.Unpickler):
         "torch.ByteStorage",
         "torch.DoubleStorage",
         "torch.FloatStorage",
-        # "torch._C.HalfStorageBase",
-        # "torch._C.QInt32StorageBase",
-        # "torch._C.QInt8StorageBase",
-        # "torch.storage._TypedStorage",
+        "torch._C.HalfStorageBase",
+        "torch._C.QInt32StorageBase",
+        "torch._C.QInt8StorageBase",
+        "torch.storage._TypedStorage",
     ]
 
     for item in __ALLOWLIST:

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ if __name__ == "__main__":
         author=AUTHOR,
         license=LICENSE,
         tests_require=["pytest"],
-        data_files=[("/configs", ["configs/default.yaml"])],
+        data_files=[("configs", ["configs/default.yaml"])],
     )

--- a/test/test_debug.py
+++ b/test/test_debug.py
@@ -55,7 +55,6 @@ class TestDebug(MultiProcessTestCase):
                 encrypted_tensor.add(10)
 
             # Ensure incorrect validation works properly for value
-            # tensor2 = get_random_test_tensor(size=(2, 2), is_float=True)
             encrypted_tensor.add = lambda y: crypten.cryptensor(tensor)
             with self.assertRaises(ValueError):
                 encrypted_tensor.add(10)

--- a/test/test_gradients.py
+++ b/test/test_gradients.py
@@ -1222,7 +1222,6 @@ class TestTFP(MultiProcessTestCase, TestGradients):
         super(TestTFP, self).tearDown()
 
 
-# @unittest.skip("Almost all TTP tests are timing out")
 class TestTTP(MultiProcessTestCase, TestGradients):
     def setUp(self):
         self._original_provider = cfg.mpc.provider


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

This is a small change that has three targets (in order of importance):
* Re-enable two tests that were disabled in an earlier diff. 
* Setup using the command "python3 setup.py install --user" (see https://github.com/facebookresearch/CrypTen/issues/438) does not work. While users can still use "pip3 install -e ." to install crypten. The small change to enable that alternate mode of installation will not break pip3 installation. 
* Remove some commented-out text. 

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
Tested the installation using the two methods mentioned above. 
For other tests, relying on CI. 

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
