### PR TITLE
 The 'sklearn' PyPI package is deprecated, use 'scikit-learn'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyyaml>=5.3.1
 tensorboard
 future
 scipy>=1.6.0
-sklearn
+scikit-learn


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
