### PR TITLE
bugfix: Fixed inappropriate comparison using `is`

### DIFF
--- a/crypten/mpc/mpc.py
+++ b/crypten/mpc/mpc.py
@@ -54,7 +54,7 @@ class MPCTensor(CrypTensor):
 
         # create the MPCTensor:
         tensor_type = ptype.to_tensor()
-        if tensor is []:
+        if tensor == []:
             self._tensor = torch.tensor([], device=device)
         else:
             self._tensor = tensor_type(tensor=tensor, device=device, *args, **kwargs)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue
In file [mpc.py](https://github.com/facebookresearch/CrypTen/blob/0bb9b13931abb03244b18abc358045205ff75a6a/crypten/mpc/mpc.py#L57), there was a comparison that used `is` operator instead of using `==`. In Python, `==` should be used to compare object.

For example, running the following code will give you the output:
```python
x = []
print(x is [])
```
```
False
```


## How Has This Been Tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
Not tested. This is basic logic.


## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
